### PR TITLE
create CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+Community Code of Conduct
+=========================
+
+Our Pledge
+----------
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age,
+body size, disability, ethnicity, sex characteristics, gender identity and
+expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+Our Standards
+-------------
+
+- Being open. Members of the community are open to collaboration.
+- Focusing on what is best for the community. We're respectful of the processes set forth in the community, and we work within them.
+- Acknowledging time and effort. We're respectful of the volunteer efforts that permeate the community. We're thoughtful when addressing the efforts of others, keeping in mind that often times the labour was completed simply for the good of the community.
+- Being respectful of differing viewpoints and experiences. We're receptive to constructive comments and criticism, as the experiences and skill sets of other members contribute to the whole of our efforts.
+- Being considerate towards other community members. We're attentive in our communications and we're tactful when approaching differing views.
+- Using welcoming and inclusive language. We're accepting of all who wish to take part in our activities, fostering an environment where anyone can participate and everyone can make a difference.
+- Take responsibility for our words and our actions. We can all make mistakes; when we do, we take responsibility for them. If someone has been harmed or offended, we listen carefully and respectfully, and work to right the wrong.
+- Step down considerately. When somebody leaves or disengages from the project, we ask that they do so in a way that minimises disruption to the project.
+- Ask for help when unsure. Nobody is expected to be perfect in this community. Asking questions early avoids many problems later, so questions are encouraged, though they may be directed to the appropriate forum. Those who are asked should be responsive and helpful.
+- Value decisiveness, clarity and consensus. Disagreements, social and technical, are normal, but we do not allow them to persist and fester leaving others uncertain of the agreed direction. We expect participants in the project to resolve disagreements constructively. When they cannot, we escalate the matter to structures with designated leaders to arbitrate and provide clarity and direction.
+
+Our Responsibilities
+--------------------
+
+Project maintainers are responsible for clarifying the standards of acceptable behaviour and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behaviour.
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviour that they deem inappropriate, threatening, offensive, or harmful.
+
+Enforcement
+-----------
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported to the community leaders responsible
+for enforcement at [oss@gchq.gov.uk](mailto:oss@gchq.gov.uk). All complaints will be reviewed and investigated promptly and fairly, and will
+result in a response that is deemed necessary and appropriate to the circumstances. The community leaders responsible
+for enforcement are obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Attribution
+-----------
+This Code of Conduct has been adapted with modifications from the Contributor Covenant (version 1.4), the Python Code of conduct and the Ubuntu Code of Conduct (version 2.0).


### PR DESCRIPTION
This PR creates the Code of Conduct document, CODE_OF_CONDUCT.md, for the project Vanguard.

This PR addresses https://github.com/gchq/Vanguard/issues/27#issue-2130536791