### PR TITLE
remove: byte order mark from .pylintrc, and pre-commit exception

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -109,7 +109,6 @@ repos:
         language: python
         exclude:
           (?x)^(
-            .pylintrc|
             docs/source/_static/.+.png
           )$
 #      - id: docstring-spaces

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,4 +1,4 @@
-﻿[MAIN]
+[MAIN]
 
 # Analyse import fallback blocks. This can be used to support both Python 2 and
 # 3 compatible code, which means that the block might have code that exists


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- CI related changes

### Description
Removed the BOM from `.pylintrc` and the exception for it in `.pre-commit-config.yaml`.

Resolves #84 

### How Has This Been Tested?
`pre-commit` passes.

### Does this PR introduce a breaking change?
No

### Screenshots
N/A

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
