### PR TITLE
Change some .ipynb cell types from raw to markdown

### DIFF
--- a/examples/notebooks/decorator_walkthrough.ipynb
+++ b/examples/notebooks/decorator_walkthrough.ipynb
@@ -89,8 +89,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "therapeutic-scope",
+   "cell_type": "markdown",
+   "id": "93148157-8ba8-4255-9b61-9b8404199ace",
    "metadata": {},
    "source": [
     "This function will fail if it passed anything other than a string, but it will raise an exc:`AttributeError`:"
@@ -109,8 +109,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "pretty-healthcare",
+   "cell_type": "markdown",
+   "id": "05afab74-d041-411c-9558-509fce4158ad",
    "metadata": {},
    "source": [
     "It would be preferable for the function to raise a exc:`TypeError`, which could be achieved with a simple ``try``/``except`` block, but it's possible that ``is_py_file`` cannot be edited, or that this change needs to be made to multiple functions which could each take a different number of inputs. Instead, a decorator can be used to check that ``file_path`` is a string, without mutating ``is_py_file``:"
@@ -225,8 +225,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "progressive-belgium",
+   "cell_type": "markdown",
+   "id": "e6b71d1b-7253-4abc-86d0-3348517832f6",
    "metadata": {},
    "source": [
     "Decorators in Vanguard\n",
@@ -286,8 +286,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "legitimate-allen",
+   "cell_type": "markdown",
+   "id": "642cfcc6-e1d4-412b-af61-1dffa2f3a173",
    "metadata": {},
    "source": [
     "This function will be applied to the ``train_x``, ``train_y`` and ``y_std`` inputs to the newly decorated class. In order to work with these parameters, the :func:`~vanguard.decoratorutils.wrapping.process_args` function comes in handy:"
@@ -307,8 +307,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "significant-olympus",
+   "cell_type": "markdown",
+   "id": "eba12510-5b41-477e-9186-a36ffcf52509",
    "metadata": {},
    "source": [
     "This returns a parameter mapping, essentially ensuring that all parameters are treated as keyword arguments, even the ones which were passed as positional arguments. This function can be used in the :meth:`~vanguard.decoratorutils.basedecorator.Decorator._decorate_class` method of the decorator to intercept arguments passed to the decorated class:"
@@ -350,8 +350,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "excessive-enforcement",
+   "cell_type": "markdown",
+   "id": "9f65e1ae-bf07-45a0-b79d-dc654a3838a8",
    "metadata": {},
    "source": [
     "There are a few things to note here:\n",
@@ -388,8 +388,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "uniform-sauce",
+   "cell_type": "markdown",
+   "id": "16090b3b-0075-4e7f-9afb-0736059e438d",
    "metadata": {},
    "source": [
     "Class Wrapping\n",
@@ -410,8 +410,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "continuing-abortion",
+   "cell_type": "markdown",
+   "id": "c82cec35-74de-4518-a00f-402d19c93c82",
    "metadata": {},
    "source": [
     "This can fixed by using the :func:`~vanguard.decoratorutils.wrapping.wraps_class` decorator, which behaves a lot like the func:`functools.wraps`, only for classes:"
@@ -471,8 +471,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "crucial-lover",
+   "cell_type": "markdown",
+   "id": "ad008765-e487-4ef1-8b75-b55dfd335ed9",
    "metadata": {},
    "source": [
     ".. warning::\n",
@@ -480,8 +480,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "joined-secretary",
+   "cell_type": "markdown",
+   "id": "064506c5-4b3b-4088-afcd-01a5fe475ce0",
    "metadata": {},
    "source": [
     ".. note::\n",
@@ -490,8 +490,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "cubic-hanging",
+   "cell_type": "markdown",
+   "id": "7474c61b-57ae-4db5-a920-d67bf6a02077",
    "metadata": {},
    "source": [
     "Decorator Parameters\n",
@@ -547,8 +547,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "adult-symposium",
+   "cell_type": "markdown",
+   "id": "6f5e73d3-5cd8-4b59-b894-7b46eb2075d9",
    "metadata": {},
    "source": [
     "Handling Different Controllers\n",
@@ -593,8 +593,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "handled-fault",
+   "cell_type": "markdown",
+   "id": "74f39099-ec4c-4221-95ee-7b947975dc26",
    "metadata": {},
    "source": [
     ".. note::\n",
@@ -602,8 +602,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "controlled-brisbane",
+   "cell_type": "markdown",
+   "id": "b542fe83-35bf-4354-bba9-b18d93379914",
    "metadata": {},
    "source": [
     "These methods are expected, but have been overwritten. Most of these methods are not expected to affect the decorator either, with the exception of ``__init__``. Although ``__init__`` could be ignored and the code would run, class:`~vanguard.uncertainty.GaussianUncertaintyGPController` takes a ``train_x_std`` parameter which would need to be shuffled also. This would be a problem for a user of the decorator, and can be avoided by adding the ability to pass additional parameters to be shuffled:"

--- a/examples/notebooks/intro_to_gps.ipynb
+++ b/examples/notebooks/intro_to_gps.ipynb
@@ -98,8 +98,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "9855e916",
+   "cell_type": "markdown",
+   "id": "8031bffb-fc83-4718-a8bd-95f2d3f0d69c",
    "metadata": {},
    "source": [
     "The Mathematics Behind Gaussian Processes\n",
@@ -159,8 +159,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "6b4c20f8",
+   "cell_type": "markdown",
+   "id": "72457fc2-59e7-4f11-b680-02ef3836b167",
    "metadata": {},
    "source": [
     "Python Implementations of GPs\n",
@@ -183,12 +183,12 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "9275c8f1",
+   "cell_type": "markdown",
+   "id": "660aea91-feb7-4920-9cf4-05d8c05a4a44",
    "metadata": {},
    "source": [
     "Sci-kit Learn\n",
-    "~~~~~~~~~~~~~\n",
+    "-------------\n",
     "\n",
     "The most straightforward implementation is in `sklearn`, with a trademark light-weight API. We first need a *kernel*, which is the Python equivalent which implements the covariance function :math:`k`. The :class:`~sklearn.gaussian_process.kernels.RBF` kernel is the implementation of the squared exponential covariance function mentioned above. We compose it with a class:`~sklearn.gaussian_process.kernels.ConstantKernel`, to allow us to scale the covariance to accommodate the prior:"
    ]
@@ -222,8 +222,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "2f29c934",
+   "cell_type": "markdown",
+   "id": "a1457232-2fc1-48a8-9c4a-2003d76eaa7f",
    "metadata": {},
    "source": [
     "As is common with ``sklearn`` we call the :meth:`~sklearn.gaussian_process.GaussianProcessRegressor.fit` method, which will tune the hyperparameters in the mean and the kernel of the Gaussian process:"
@@ -240,8 +240,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "98e10928",
+   "cell_type": "markdown",
+   "id": "49d84442-9f2a-472d-8f8c-4a2f217e9b8d",
    "metadata": {},
    "source": [
     "Our predictions can then be pulled from the model using the :meth:`~sklearn.gaussian_process.GaussianProcessRegressor.predict` method. By predicting across a mesh of points over the training data, we can see the effects of the uncertainty on the plot."
@@ -275,12 +275,12 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "02d83228",
+   "cell_type": "markdown",
+   "id": "c8bdf5ce-bdae-452d-8ade-2bf9bb4fb0da",
    "metadata": {},
    "source": [
     "GPyTorch\n",
-    "~~~~~~~~\n",
+    "--------\n",
     "\n",
     "Sci-kit learn is a great choice for implementing a quick GP, but it has very little room for adjustment and it is almost impossible to do anything advanced. On the other side of the spectrum, ``gpytorch`` allows for an almost unbounded set of features by fully exposing all parts of the GP architecture. Our initial kernel is identical to the above example, composing the :class:`~gpytorch.kernels.RBFKernel` with a class:`~gpytorch.kernels.ScaleKernel`:"
    ]
@@ -296,8 +296,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "b901abf4",
+   "cell_type": "markdown",
+   "id": "53482a42-69d6-4796-903f-7fede76f3066",
    "metadata": {},
    "source": [
     "We also now have freedom over the mean. A good starting place is the class:`~gpytorch.means.ConstantMean`:"
@@ -314,8 +314,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "3e19e820",
+   "cell_type": "markdown",
+   "id": "bf689252-fce8-409f-a37f-d35f21082417",
    "metadata": {},
    "source": [
     "Unlike ``sklearn``, we need to specify a likelihood function, which controls the mapping from the image of points under a function (:math:`f(x)`) to the labels. This can be as simple as adding some Gaussian noise as in the class:`~gpytorch.likelihoods.GaussianLikelihood`, or something more complex to enable binary classification as in the class:`~gpytorch.likelihoods.BernoulliLikelihood`. However, the former is the best choice for a simple model:"
@@ -332,8 +332,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "1e833d1c",
+   "cell_type": "markdown",
+   "id": "04b8aff5-9418-4dd5-9cc4-829af4c1c67d",
    "metadata": {},
    "source": [
     "Finally, we need to build a model class to handle the inference. GPyTorch makes you do this yourself to allow you full control, but it can seem like a daunting task. For a simple case, one need only subclass the class:`~gpytorch.models.ExactGP` class, and specify a ``forward`` method to pass data through the mean and covariance functions. The class:`~gpytorch.distributions.MultivariateNormal` instance is the standard output for these functions, allowing us to work with a distribution directly instead of separating the mean and variance."
@@ -361,8 +361,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "45619c92",
+   "cell_type": "markdown",
+   "id": "e1800ee8-7a74-4c9f-b768-48cb9e95975a",
    "metadata": {},
    "source": [
     "We can then instantiate our model. Note that GPyTorch works with tensors instead of numpy arrays, so we need to ensure that we convert them before passing them to the model."
@@ -380,8 +380,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "7b1867ac",
+   "cell_type": "markdown",
+   "id": "e204c26e-e58c-4729-a677-9633f091cd3e",
    "metadata": {},
    "source": [
     "Fitting the model is a much more manual task here than it was before, requiring us to build our own function. We make use of the class:`~torch.optim.Adam` optimiser, and also the class:`~gpytorch.mlls.ExactMarginalLogLikelihood` class. This will compute the marginal log likelihood of the model when applied to some data, and can be turned into \"loss\" functions by negating them. There are a few variations, but this one is sufficient for this simple case. We wrap all of these into a ``fit`` function to broadly emulate the one from ``sklearn``:"
@@ -483,12 +483,12 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "b919e98b",
+   "cell_type": "markdown",
+   "id": "d237ba87-a19f-4546-aa6d-9bfaadafe42a",
    "metadata": {},
    "source": [
     "Vanguard\n",
-    "~~~~~~~~\n",
+    "--------\n",
     "\n",
     "Finally, we come to Vanguard, which is built upon GPyTorch to allow advanced GP functionality without requiring too much knowledge from the user. Given its base, Vanguard can be adjusted to use many components from GPyTorch, and also allows for easy composability of the advanced features made available. Instead of composing our own kernels (which is still possible) we use the specific class:`~vanguard.kernels.ScaledRBFKernel`. Note that components are passed around in Vanguard as *uninstantiated classes* instead of instances, which enables much of the composability."
    ]
@@ -505,8 +505,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "d2bfba08",
+   "cell_type": "markdown",
+   "id": "861f571b-98ca-4c89-8054-8f5509f702a4",
    "metadata": {},
    "source": [
     "Instead of a ``predict`` method, Vanguard opts for the :meth:`~vanguard.base.gpcontroller.GPController.posterior_over_point` method, which will return an instance of a class:`~vanguard.base.posteriors.Posterior` class, allowing some of the features to alter how the distribution leads to predictions."
@@ -526,8 +526,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "79175189",
+   "cell_type": "markdown",
+   "id": "dade6135-bbab-4970-ac3f-0d2c960e7347",
    "metadata": {},
    "source": [
     "To simplify matters, one can just call the :meth:`~vanguard.base.posteriors.Posterior.confidence_interval` method instead of working directly with the covariance matrix:"


### PR DESCRIPTION
Resolves #126

### PR Type

- Documentation content changes

### Description
Some cells in the .ipynb files in examples/ are type Raw. They would render better if the type was changed to Markdown format.

This PR changes some cells in these files from Raw to Markdown.

### How Has This Been Tested?
Existing tests pass as expected.

### Does this PR introduce a breaking change?
No.

### Screenshots

(Write your answer here.)

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
