### PR TITLE
feat: remove explicit types from docstrings

### DIFF
--- a/vanguard/base/basecontroller.py
+++ b/vanguard/base/basecontroller.py
@@ -514,7 +514,7 @@ def _catch_and_check_module_errors(
         """
         Decorate a particular module (mean/kernel).
 
-        :param torch.nn.Module module_class: The model class to which to apply error handling.
+        :param module_class: The model class to which to apply error handling.
         """
         @wraps_class(module_class)
         class InnerClass(module_class):

--- a/vanguard/base/metrics.py
+++ b/vanguard/base/metrics.py
@@ -119,7 +119,7 @@ class MetricsTracker:
         the user when combined with :meth:`print_metrics` and a
         customised format string.
 
-        :param float loss_value: The loss.
+        :param loss_value: The loss.
         :param controller: The controller instance.
         """
         self._iteration += 1

--- a/vanguard/base/standardise.py
+++ b/vanguard/base/standardise.py
@@ -28,7 +28,7 @@ class StandardiseXModule:
                 Can be an array in the case of multiple features.
         :param scale: The scale (i.e. standard deviation) of the standard scaling.
                 Can be an array in the case of multiple features.
-        :param torch.device,None device: The device on which the mean and scale parameters should live.
+        :param device: The device on which the mean and scale parameters should live.
         :param dtype: Datatype to specify when creating torch tensors.
         """
         self.mean = torch.as_tensor(mean, device=device, dtype=dtype)

--- a/vanguard/classification/likelihoods.py
+++ b/vanguard/classification/likelihoods.py
@@ -84,8 +84,8 @@ class DirichletKernelDistribution(torch.distributions.Dirichlet):
         """
         Initialise self.
 
-        :param torch.Tensor label_matrix: (``n_data_points``,``n_classes``) A binary indicator matrix encoding the class
-                                                                            to which each data point belongs.
+        :param label_matrix: (``n_data_points``,``n_classes``) A binary indicator matrix encoding the class to which
+                                                               each data point belongs.
         :param kernel_matrix: (``n_data_points``,``n_data_points``) The evaluated kernel matrix.
         :param alpha: (``n_classes``,) The Dirichlet prior concentration parameters.
         """

--- a/vanguard/classification/models.py
+++ b/vanguard/classification/models.py
@@ -22,8 +22,8 @@ class DummyKernelDistribution:
         """
         Initialise self.
 
-        :param torch.Tensor labels: The one-hot labels.
-        :param torch.Tensor kernel: The kernel matrix.
+        :param labels: The one-hot labels.
+        :param kernel: The kernel matrix.
         """
         self.labels = labels
         self.kernel = kernel

--- a/vanguard/datasets/basedataset.py
+++ b/vanguard/datasets/basedataset.py
@@ -33,15 +33,15 @@ class Dataset:
         """
         Initialise self.
 
-        :param numpy.ndarray[float] train_x: The training inputs.
-        :param numpy.ndarray[float],float train_x_std: The standard deviation(s) of the training inputs.
-        :param numpy.ndarray[float] train_y: The training outputs.
-        :param numpy.ndarray[float],float train_y_std: The standard deviation(s) of the training outputs.
-        :param numpy.ndarray[float] test_x: The test inputs.
-        :param numpy.ndarray[float],float test_x_std: The standard deviation(s) of the test inputs.
-        :param numpy.ndarray[float] test_y: The test outputs.
-        :param numpy.ndarray[float],float test_y_std: The standard deviation(s) of the test outputs.
-        :param float significance: The recommended significance value to be used for confidence intervals.
+        :param train_x: The training inputs.
+        :param train_x_std: The standard deviation(s) of the training inputs.
+        :param train_y: The training outputs.
+        :param train_y_std: The standard deviation(s) of the training outputs.
+        :param test_x: The test inputs.
+        :param test_x_std: The standard deviation(s) of the test inputs.
+        :param test_y: The test outputs.
+        :param test_y_std: The standard deviation(s) of the test outputs.
+        :param significance: The recommended significance value to be used for confidence intervals.
             Note that this value does not necessarily have any bearing on the data.
         """
         self.train_x = train_x

--- a/vanguard/datasets/classification.py
+++ b/vanguard/datasets/classification.py
@@ -30,7 +30,7 @@ class BinaryStripeClassificationDataset(Dataset):
         """
         Initialise self.
 
-        :param int num_train_points: The number of training points.
+        :param num_train_points: The number of training points.
         :param num_test_points: The number of testing points.
         """
         train_x = np.linspace(0, 1, num_train_points)
@@ -65,12 +65,12 @@ class MulticlassGaussianClassificationDataset(Dataset):
         """
         Initialise self.
 
-        :param int num_train_points: The number of training points.
-        :param int num_test_points: The number of testing points.
-        :param int num_classes: The number of classes.
-        :param float,int covariance_scale: The covariance matrix will be this value times the unit matrix.
+        :param num_train_points: The number of training points.
+        :param num_test_points: The number of testing points.
+        :param num_classes: The number of classes.
+        :param covariance_scale: The covariance matrix will be this value times the unit matrix.
             Defaults to 1.0.
-        :param int,None seed: Used to seed the quantile creation, defaults to None (not reproducible).
+        :param seed: Used to seed the quantile creation, defaults to None (not reproducible).
         """
         self.num_classes = num_classes
 
@@ -91,8 +91,8 @@ class MulticlassGaussianClassificationDataset(Dataset):
         """
         Plot the data.
 
-        :param str cmap: The colour map to be used.
-        :param float alpha: The transparency of the points.
+        :param cmap: The colour map to be used.
+        :param alpha: The transparency of the points.
         """
         ax = plt.gca()
         scatter = plt.scatter(self.train_x[:, 0], self.train_x[:, 1], c=self.train_y, cmap=cmap, alpha=alpha)
@@ -104,9 +104,9 @@ class MulticlassGaussianClassificationDataset(Dataset):
         """
         Plot a prediction.
 
-        :param numpy.ndarray prediction: The predicted classes.
-        :param str cmap: The colour map to be used.
-        :param float alpha: The transparency of the points.
+        :param prediction: The predicted classes.
+        :param cmap: The colour map to be used.
+        :param alpha: The transparency of the points.
         """
         correct_prediction = (prediction == self.test_y)
         proportion_correct: float = correct_prediction.sum() / len(self.test_x)  # type: ignore
@@ -126,9 +126,9 @@ class MulticlassGaussianClassificationDataset(Dataset):
         """
         Plot a confusion matrix based on a specific prediction.
 
-        :param numpy.ndarray prediction: The predicted classes.
-        :param str cmap: The colour map to be used.
-        :param str text_size: The text size to be used for the labels.
+        :param prediction: The predicted classes.
+        :param cmap: The colour map to be used.
+        :param text_size: The text size to be used for the labels.
         """
         matrix = np.zeros((self.num_classes, self.num_classes))
         for true_label, predicted_label in zip(self.test_y, prediction):
@@ -165,10 +165,10 @@ class BinaryGaussianClassificationDataset(MulticlassGaussianClassificationDatase
         """
         Initialise self.
 
-        :param int num_train_points: The number of training points.
+        :param num_train_points: The number of training points.
         :param num_test_points: The number of testing points.
-        :param float,int covariance_scale: The covariance matrix will be this value times the unit matrix.
+        :param covariance_scale: The covariance matrix will be this value times the unit matrix.
             Defaults to 1.0.
-        :param int,None seed: Used to seed the quantile creation, defaults to None (not reproducible).
+        :param seed: Used to seed the quantile creation, defaults to None (not reproducible).
         """
         super().__init__(num_train_points, num_test_points, num_classes=2, covariance_scale=covariance_scale, seed=seed)

--- a/vanguard/datasets/synthetic.py
+++ b/vanguard/datasets/synthetic.py
@@ -57,15 +57,15 @@ class SyntheticDataset(Dataset):
         """
         Initialise self.
 
-        :param Iterable[function] functions: The functions to be used to generate the synthetic data.
-        :param float output_noise: The standard deviation for the output standard deviation, defaults to 0.1.
+        :param functions: The functions to be used to generate the synthetic data.
+        :param output_noise: The standard deviation for the output standard deviation, defaults to 0.1.
         :param train_input_noise_bounds: The lower, upper bounds of the linearly varying noise
             for the training input. Defaults to (0.01, 0.05).
         :param test_input_noise_bounds: The lower, upper bounds of the linearly varying noise
             for the testing input. Defaults to (0.01, 0.03).
-        :param int n_train_points: The total number of training points.
-        :param int n_test_points: The total number of testing points.
-        :param float significance: The significance to be used.
+        :param n_train_points: The total number of training points.
+        :param n_test_points: The total number of testing points.
+        :param significance: The significance to be used.
         """
         self.functions = list(functions)
 
@@ -91,12 +91,11 @@ class SyntheticDataset(Dataset):
         """
         Create some sample data.
 
-        :param int n_points: The number of points to create.
-        :param tuple[float] input_noise_bounds: The lower, upper bounds for the resulting input noise.
-        :param float output_noise_level: The amount of noise applied to the inputs.
-        :param float interval_length: Use to scale the exact image of the function, defaults to 1.
+        :param n_points: The number of points to create.
+        :param input_noise_bounds: The lower, upper bounds for the resulting input noise.
+        :param output_noise_level: The amount of noise applied to the inputs.
+        :param interval_length: Use to scale the exact image of the function, defaults to 1.
         :return: The output and the mean and standard deviation of the input, in the form ``(x_mean, x_std), y``.
-        :rtype: tuple[tuple[numpy.ndarray[float], numpy.ndarray[float]]
         """
         x_mean = np.linspace(0, interval_length, n_points)
         x_std = np.linspace(*input_noise_bounds, n_points)
@@ -134,7 +133,7 @@ class MultidimensionalSyntheticDataset(Dataset):
         """
         Initialise self.
 
-        :param Iterable[function] functions: The functions used on each input dimension
+        :param functions: The functions used on each input dimension
                                                 (they are combined linearly to make a single output).
         """
         one_dimensional_datasets = [SyntheticDataset(functions=(function,), **kwargs) for function in functions]
@@ -171,15 +170,15 @@ class HeteroskedasticSyntheticDataset(SyntheticDataset):
         """
         Initialise self.
 
-        :param Iterable[function] functions: The functions to be used to generate the synthetic data.
-        :param float output_noise: The standard deviation for the output standard deviation, defaults to 0.1.
+        :param functions: The functions to be used to generate the synthetic data.
+        :param output_noise: The standard deviation for the output standard deviation, defaults to 0.1.
         :param train_input_noise_bounds: The lower, upper bounds of the linearly varying noise
             for the training input. Defaults to (0.01, 0.05).
         :param test_input_noise_bounds: The lower, upper bounds of the linearly varying noise
             for the testing input. Defaults to (0.01, 0.03).
-        :param int n_train_points: The total number of training points.
-        :param int n_test_points: The total number of testing points.
-        :param float significance: The significance to be used.
+        :param n_train_points: The total number of training points.
+        :param n_test_points: The total number of testing points.
+        :param significance: The significance to be used.
         """
         super().__init__(functions, output_noise, train_input_noise_bounds, test_input_noise_bounds, n_train_points,
                          n_test_points, significance)
@@ -203,15 +202,15 @@ class HigherRankSyntheticDataset(Dataset):
         """
         Initialise self.
 
-        :param Iterable[function] functions: The functions to be used to generate the synthetic data.
-        :param float output_noise: The standard deviation for the output standard deviation, defaults to 0.1.
+        :param functions: The functions to be used to generate the synthetic data.
+        :param output_noise: The standard deviation for the output standard deviation, defaults to 0.1.
         :param train_input_noise_bounds: The lower, upper bounds of the linearly varying noise
             for the training input. Defaults to (0.01, 0.05).
         :param test_input_noise_bounds: The lower, upper bounds of the linearly varying noise
             for the testing input. Defaults to (0.01, 0.03).
-        :param int n_train_points: The total number of training points.
-        :param int n_test_points: The total number of testing points.
-        :param float significance: The significance to be used.
+        :param n_train_points: The total number of training points.
+        :param n_test_points: The total number of testing points.
+        :param significance: The significance to be used.
         """
         self.functions = list(functions)
 
@@ -239,12 +238,11 @@ class HigherRankSyntheticDataset(Dataset):
         """
         Create some sample data.
 
-        :param int n_points: The number of points to create.
-        :param tuple[float] input_noise_bounds: The lower, upper bounds for the resulting input noise.
-        :param float output_noise_level: The amount of noise applied to the inputs.
-        :param float interval_length: Use to scale the exact image of the function, defaults to 1.
+        :param n_points: The number of points to create.
+        :param input_noise_bounds: The lower, upper bounds for the resulting input noise.
+        :param output_noise_level: The amount of noise applied to the inputs.
+        :param interval_length: Use to scale the exact image of the function, defaults to 1.
         :return: The output and the mean and standard deviation of the input, in the form ``(x_mean, x_std), y``.
-        :rtype: tuple[tuple[numpy.ndarray[float], numpy.ndarray[float]]
         """
         x_mean = np.linspace(0, interval_length, n_points)
         x_mean = np.random.randn(n_points, 2, 2) + x_mean.reshape(-1, 1, 1)

--- a/vanguard/distribute/aggregators.py
+++ b/vanguard/distribute/aggregators.py
@@ -22,11 +22,11 @@ class BaseAggregator:
         """
         Initialise self.
 
-        :param list[torch.Tensor] means: (d,) Each element is an array of a single expert's predictive mean
+        :param means: (d,) Each element is an array of a single expert's predictive mean
                 at the evaluation points.
-        :param list[torch.Tensor] covars: (d,d) The individual experts posterior predictive covariance
+        :param covars: (d,d) The individual experts posterior predictive covariance
                 at the test points.
-        :param torch.Tensor prior_var: (d,) The diagonal of the test kernel with added noise.
+        :param prior_var: (d,) The diagonal of the test kernel with added noise.
         """
         self.means = torch.stack(means).type(torch.float32)
         self.covars = torch.stack(covars).type(torch.float32)
@@ -47,7 +47,6 @@ class BaseAggregator:
         Combine the predictions of the individual experts into a single PoE prediction.
 
         :return: The mean and variance of the combined experts.
-        :rtype: tuple[torch.Tensor]
         """
         raise NotImplementedError
 
@@ -60,12 +59,11 @@ class BaseAggregator:
             prior and posterior :cite:`Deisenroth15`). ``delta_diff`` and ``delta_val`` are the same in
             class:`XBCMAggregator`.
 
-        :param torch.Tensor delta_diff: The delta used to determine if correction is applied
+        :param delta_diff: The delta used to determine if correction is applied
                 (proxy for in-vs-out of training data).
-        :param torch.Tensor delta_val: The delta value to be corrected. Must be the same shape as ``delta_diff``.
+        :param delta_val: The delta value to be corrected. Must be the same shape as ``delta_diff``.
 
         :return: The corrected expert weights, the same shape as ``delta_diff``.
-        :rtype: torch.Tensor
         """
         in_training_data = (delta_diff > 1)
         not_in_training_data = (delta_diff <= 1)

--- a/vanguard/distribute/decorator.py
+++ b/vanguard/distribute/decorator.py
@@ -50,14 +50,14 @@ class Distributed(TopMostDecorator, Generic[ControllerT]):
         """
         Initialise self.
 
-        :param int n_experts: The number of partitions in which to split the data. Defaults to 3.
-        :param float subset_fraction: The proportion of the training data to be used to train the hyperparameters.
+        :param n_experts: The number of partitions in which to split the data. Defaults to 3.
+        :param subset_fraction: The proportion of the training data to be used to train the hyperparameters.
             Defaults to 0.1.
         :param seed: The seed used for creating the subset of the training data used to train the hyperparameters.
             Defaults to 42.
-        :param type aggregator_class: The class to be used for aggregation. Defaults to
+        :param aggregator_class: The class to be used for aggregation. Defaults to
             class:`~vanguard.distribute.aggregators.RBCMAggregator`.
-        :param type partitioner_class: The class to be used for partitioning. Defaults to
+        :param partitioner_class: The class to be used for partitioning. Defaults to
             class:`~vanguard.distribute.partitioners.KMeansPartitioner`.
 
         :Keyword Arguments:
@@ -134,7 +134,6 @@ class Distributed(TopMostDecorator, Generic[ControllerT]):
                     This may not behave as expected on CUDA.
 
                 :returns: The losses for each expert.
-                :rtype: list[float]
                 """
                 if self.device.type == "cuda":
                     warnings.warn("Collecting expert losses may not behave as expected on CUDA.", RuntimeWarning)
@@ -166,10 +165,9 @@ class Distributed(TopMostDecorator, Generic[ControllerT]):
                 """
                 Aggregate an iterable of posteriors.
 
-                :param torch.Tensor x: The point at which the posteriors have been evaluated.
-                :param Iterable[vanguard.base.posteriors.Posterior] expert_posteriors: The expert posteriors.
+                :param x: The point at which the posteriors have been evaluated.
+                :param expert_posteriors: The expert posteriors.
                 :return: The aggregated posterior.
-                :rtype: vanguard.base.posteriors.Posterior
                 """
                 expert_distributions = (posterior.condensed_distribution for posterior in expert_posteriors)
                 expert_means_and_covars = [(distribution.mean, distribution.covariance_matrix)
@@ -202,15 +200,14 @@ class Distributed(TopMostDecorator, Generic[ControllerT]):
                 """
                 Aggregate the means and variances from the expert predictions.
 
-                :param array_like[float] x: (n_preds, n_features) The predictive inputs.
-                :param list[tuple[Tensor[float]]] means_and_covars: A list of (``mean``, ``variance``) pairs
+                :param x: (n_preds, n_features) The predictive inputs.
+                :param means_and_covars: A list of (``mean``, ``variance``) pairs
                         representing the posterior predicted and mean for each expert controller.
                 :returns: (``means``, ``covar``) where:
 
                     * ``means``: (n_preds,) The posterior predictive mean,
                     * ``covar``: (n_preds, n_preds) The posterior predictive covariance.
 
-                :rtype: tuple[torch.Tensor]
                 """
                 prior_var = None
                 if issubclass(self.aggregator_class, (BCMAggregator, RBCMAggregator, XBCMAggregator, XGRBCMAggregator)):
@@ -240,9 +237,8 @@ def _create_subset(*arrays: Union[NDArray[np.floating], float],
     """
     Return subsets of the arrays along the same random indices.
 
-    :param numpy.ndarray arrays: Subscriptable arrays. If an entry is not subscriptable it is returned as is.
+    :param arrays: Subscriptable arrays. If an entry is not subscriptable it is returned as is.
     :returns: The subsetted arrays.
-    :rtype: list[array_like,Any]
 
     :Example:
         >>> x = np.array([1, 2, 3, 4, 5])

--- a/vanguard/distribute/partitioners.py
+++ b/vanguard/distribute/partitioners.py
@@ -32,10 +32,10 @@ class BasePartitioner:
         """
         Initialise self.
 
-        :param numpy.ndarray train_x: The mean of the inputs.
-        :param int n_experts: The number of partitions in which to split the data. Defaults to 3.
-        :param bool communication: If True, A communications expert will be included. Defaults to False.
-        :param int seed: The seed for the random state. Defaults to 42.
+        :param train_x: The mean of the inputs.
+        :param n_experts: The number of partitions in which to split the data. Defaults to 3.
+        :param communication: If True, A communications expert will be included. Defaults to False.
+        :param seed: The seed for the random state. Defaults to 42.
         """
         self.train_x = train_x
         self.n_experts = n_experts
@@ -49,7 +49,6 @@ class BasePartitioner:
         Create a partition of ``self.train_x`` across ``self.n_experts``.
 
         :return partition: A partition of length ``self.n_experts``.
-        :rtype: list[list[int]]
         """
         np.random.seed(self.seed)
 
@@ -75,9 +74,8 @@ class BasePartitioner:
         """
         Create the partition.
 
-        :param int n_clusters: The number of clusters.
+        :param n_clusters: The number of clusters.
         :return partition: A partition of shape (``n_clusters``, ``self.n_examples`` // ``n_clusters``).
-        :rtype: list[list[int]]
         """
         # TODO: should this be an abstract method?
         raise NotImplementedError
@@ -87,7 +85,6 @@ class BasePartitioner:
         Create a partition with a communications expert.
 
         :return partition: A partition of length ``self.n_experts``.
-        :rtype: list[list[int]]
         """
         size = self.n_examples // self.n_experts
         random_partition = np.random.choice(self.n_examples, size=size, replace=False).tolist()
@@ -105,9 +102,8 @@ class BasePartitioner:
         """
         Group the indices of the labels by their value.
 
-        :param Iterable labels: An array of labels.
+        :param labels: An array of labels.
         :returns groups: A list of values such that labels[groups[i][j]] == i for all j in groups[i].
-        :rtype: list[list[int]]
 
         :Example:
             >>> labels = [1, 2, 3, 2, 1, 3, 0, 9]
@@ -168,12 +164,12 @@ class KMedoidsPartitioner(BasePartitioner):
         """
         Initialise self.
 
-        :param numpy.ndarray train_x: The mean of the inputs.
-        :param gpytorch.kernels.Kernel kernel: The kernel to use for constructing the
+        :param train_x: The mean of the inputs.
+        :param kernel: The kernel to use for constructing the
                 similarity matrix in kmedoids.
-        :param int n_experts: The number of partitions in which to split the data. Defaults to 2.
-        :param bool communication: If True, A communications expert will be included. Defaults to False.
-        :param int seed: The seed for the random state. Defaults to 42.
+        :param n_experts: The number of partitions in which to split the data. Defaults to 2.
+        :param communication: If True, A communications expert will be included. Defaults to False.
+        :param seed: The seed for the random state. Defaults to 42.
         """
         super().__init__(train_x=train_x, n_experts=n_experts, communication=communication, seed=seed)
         self.kernel = kernel
@@ -190,7 +186,6 @@ class KMedoidsPartitioner(BasePartitioner):
         Construct the distance matrix.
 
         :return dist_matrix: The distance matrix.
-        :rtype: numpy.ndarray
 
         .. warning::
             The affinity matrix takes up O(N^2) memory so can't be used for large ``train_x``.

--- a/vanguard/optimise/finder.py
+++ b/vanguard/optimise/finder.py
@@ -22,8 +22,7 @@ class LearningRateFinder:
         """
         Initialise self.
 
-        :param vanguard.base.gpcontroller.GPController controller: An instantiated vanguard GP controller
-                                                                    whose learning rate shall be optimised.
+        :param controller: An instantiated vanguard GP controller whose learning rate shall be optimised.
         """
         self._controller = controller
         self._learning_rates = []
@@ -37,10 +36,10 @@ class LearningRateFinder:
         """
         Try the range of learning rates and record the loss obtained.
 
-        :param float start_lr: The smallest learning rate to try.
-        :param float end_lr: The largest learning rate to try.
-        :param int num_divisions: The number of learning rates to try.
-        :param int max_iterations: The top number of iterations of gradient descent to run for each learning rate.
+        :param start_lr: The smallest learning rate to try.
+        :param end_lr: The largest learning rate to try.
+        :param num_divisions: The number of learning rates to try.
+        :param max_iterations: The top number of iterations of gradient descent to run for each learning rate.
         """
         ratio = np.power(end_lr/start_lr, 1./num_divisions)
         self._learning_rates = [start_lr * ratio ** index for index in range(num_divisions)]
@@ -62,10 +61,9 @@ class LearningRateFinder:
         If training fails due to NaNs before the max iterations is reached,
         the loss is taken to be infinity.
 
-        :param float lr: The learning rate.
-        :param int max_iterations: The maximum number of gradient descent iterations to run.
+        :param lr: The learning rate.
+        :param max_iterations: The maximum number of gradient descent iterations to run.
         :returns: The loss at the end of training with the given learning rate.
-        :rtype: float
         """
         self._controller.learning_rate = lr
         try:

--- a/vanguard/optimise/optimiser.py
+++ b/vanguard/optimise/optimiser.py
@@ -35,11 +35,11 @@ class SmartOptimiser(Generic[OptimiserT]):
         """
         Initialise self.
 
-        :param type optimiser_class: An uninstantiated subclass of class:`torch.optim.Optimizer` to be used
+        :param optimiser_class: An uninstantiated subclass of class:`torch.optim.Optimizer` to be used
             to create the internal optimiser.
-        :param torch.nn.Module initial_modules: Initial modules whose parameters will be added to the
+        :param initial_modules: Initial modules whose parameters will be added to the
             internal optimiser.
-        :param int,None early_stop_patience: How many consecutive gradient steps of worsening loss to allow before
+        :param early_stop_patience: How many consecutive gradient steps of worsening loss to allow before
             stopping early. Defaults to ``None`` which disables early stopping.
         :param optimiser_kwargs: Additional keyword arguments to be passed to the internal optimiser.
         """

--- a/vanguard/optimise/schedule.py
+++ b/vanguard/optimise/schedule.py
@@ -17,7 +17,7 @@ class ApplyLearningRateScheduler(Generic[LRSchedulerT]):
     """
     def __init__(self, scheduler_class: Type[LRSchedulerT], *args, **kwargs):
         """
-        :param type scheduler_class: The (uninstantiated) torch learning rate scheduler to be used.
+        :param scheduler_class: The (uninstantiated) torch learning rate scheduler to be used.
         """
         self.scheduler_class = scheduler_class
         self.scheduler_kwargs = kwargs

--- a/vanguard/warps/basefunction.py
+++ b/vanguard/warps/basefunction.py
@@ -172,7 +172,6 @@ class WarpFunction(gpytorch.Module):
             parameters and keeping them frozen in downstream usage.
 
         :return: A copy of self with parameters frozen.
-        :rtype: WarpFunction
         """
         new_warp = self.copy()
         # Overwrite parameters method with an iterator

--- a/vanguard/warps/warpfunctions.py
+++ b/vanguard/warps/warpfunctions.py
@@ -4,7 +4,6 @@ There are several pre-defined warp functions implementing some common maps.
 from typing import Tuple, Union
 
 import numpy as np
-import numpy.typing
 import torch
 import torch.nn.functional
 
@@ -95,7 +94,6 @@ class PositiveAffineWarpFunction(AffineWarpFunction):
 
         :param y_values: A set of values for which :math:`ay + b` must ultimately hold.
         :returns: The two values needed to establish the same bounds on :math:`a` and :math:`b`.
-        :rtype: tuple[float]
         """
         try:
             negative_contribution = min(y_values)


### PR DESCRIPTION
Closes #57

### PR Type
- Documentation content changes


### Description
Removes the redundant (thanks to the new type hints!) explicit types from docstrings.
Checks that all uses of `numpy.typing.NDArray` are either from `import numpy.typing` or `from numpy.typing import ...`

### How Has This Been Tested?
N/A

### Does this PR introduce a breaking change?
No

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
