### PR TITLE
tests: added flaky decorator to test_fitting_with_constrained_warp

### DIFF
--- a/tests/units/warps/test_cwgp_training.py
+++ b/tests/units/warps/test_cwgp_training.py
@@ -11,7 +11,7 @@ from vanguard.kernels import ScaledRBFKernel
 from vanguard.vanilla import GaussianGPController
 from vanguard.warps import SetWarp, WarpFunction, warpfunctions
 
-from ...cases import VanguardTestCase
+from ...cases import VanguardTestCase, flaky
 
 
 class CompositionTests(VanguardTestCase):
@@ -279,6 +279,7 @@ class ConstraintTests(VanguardTestCase):
         with self.assertRaisesRegex(NanError, expected_regex):
             gp.fit(100)
 
+    @flaky
     def test_fitting_with_constrained_warp(self) -> None:
         """Should NOT throw a RuntimeError."""
         box_cox = warpfunctions.BoxCoxWarpFunction(lambda_=0)


### PR DESCRIPTION
Refs: #108

### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Tests

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

The test `tests.units.warps.test_cwgp_training.ConstraintTests.test_fitting_with_constrained_warp` is now marked as flaky, after observing issues with it. Closes #108 

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

Github workflows.

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

N/A

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
