### PR TITLE
feat: add eval pre-commit hook but exclude relevant files.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,8 +44,9 @@ repos:
       # Prevent common mistakes of `assert mck.not_called()`,
       # `assert mck.called_once_with(...)` and `mck.assert_called`
       - id: python-check-mock-methods
-#      # Check for the `eval()` built-in function - necessary for security
-#      - id: python-no-eval
+      # Check for the `eval()` built-in function - necessary for security
+      - id: python-no-eval
+        exclude: "vanguard/base/basecontroller.py|tests/units/test_base.py|vanguard/classification/models.py"
       # Check for the deprecated `.warn()` method of Python loggers
       - id: python-no-log-warn
       # Enforce that type annotations are used instead of type comments


### PR DESCRIPTION
Refs: #89

### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Feature

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

The pre-commit to check usage of `eval` has been added back into the repo, and we exclude the files where `torch.Module.eval` is used and incorrectly flags an error. Note to reviewer - is there a way to ignore only the specific lines of a file we care about, and not the entire files?

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

Pre-commit runs and passes.

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

N/A

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
