### PR TITLE
Use venv to isolate all github workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,13 @@ jobs:
           # Re-enable when going public
           # cache: pip
           # cache-dependency-path: requirements-docs.txt
+      - name: Set up virtual environment
+        run: python -m venv .venv
+      - name: Activate virtual environment
+        run: |
+          . .venv/bin/activate
+          echo PATH=$PATH >> $GITHUB_ENV
+        # ^^ This ensures that the virtual env is used for all subsequent steps.
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
       - name: Install documentation dependencies

--- a/.github/workflows/pre_commit_autoupdate.yml
+++ b/.github/workflows/pre_commit_autoupdate.yml
@@ -51,6 +51,13 @@ jobs:
           python-version: 3.9
           # Re-enable when going public
           # cache: pip
+      - name: Set up virtual environment
+        run: python -m venv .venv
+      - name: Activate virtual environment
+        run: |
+          . .venv/bin/activate
+          echo PATH=$PATH >> $GITHUB_ENV
+        # ^^ This ensures that the virtual env is used for all subsequent steps.
       - name: Upgrade Pip
         run: python -m pip install --upgrade pip
       - name: Install pre-commit

--- a/.github/workflows/pre_commit_checks.yml
+++ b/.github/workflows/pre_commit_checks.yml
@@ -21,6 +21,13 @@ jobs:
           # Re-enable when going public
           # cache: pip
           # cache-dependency-path: setup.py
+      - name: Set up virtual environment
+        run: python -m venv .venv
+      - name: Activate virtual environment
+        run: |
+          . .venv/bin/activate
+          echo PATH=$PATH >> $GITHUB_ENV
+        # ^^ This ensures that the virtual env is used for all subsequent steps.
       - name: Upgrade Pip
         run: python -m pip install --upgrade pip
       - name: Install dependencies

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -27,6 +27,13 @@ jobs:
         # Re-enable when going public
         # cache: pip
         # cache-dependency-path: requirements.txt
+    - name: Set up virtual environment
+      run: python -m venv .venv
+    - name: Activate virtual environment
+      run: |
+        . .venv/bin/activate
+        echo PATH=$PATH >> $GITHUB_ENV
+      # ^^ This ensures that the virtual env is used for all subsequent steps.
     - name: Upgrade pip
       run: python -m pip install --upgrade pip
     - name: Install test dependencies

--- a/.github/workflows/unittests_from_requirements.yml
+++ b/.github/workflows/unittests_from_requirements.yml
@@ -21,6 +21,13 @@ jobs:
         # Re-enable when going public
         # cache: pip
         # cache-dependency-path: requirements.txt
+    - name: Set up virtual environment
+      run: python -m venv .venv
+    - name: Activate virtual environment
+      run: |
+        . .venv/bin/activate
+        echo PATH=$PATH >> $GITHUB_ENV
+      # ^^ This ensures that the virtual env is used for all subsequent steps.
     - name: Upgrade pip
       run: python -m pip install --upgrade pip
     - name: Install test dependencies


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->


- CI related changes

### Description
Closes #193. Each pipeline run now creates its own `venv` virtual environment, so should be completely isolated from all other pipeline runs. Compare with #221.

### How Has This Been Tested?
Doesn't currently work - the "Install requirements" step is showing the requirements as already satisfied, which means the venv isn't being used properly

### Does this PR introduce a breaking change?
No

### Screenshots
N/A

