### PR TITLE
fix: docstring typo in classification/dirichlet.py

### DIFF
--- a/vanguard/classification/dirichlet.py
+++ b/vanguard/classification/dirichlet.py
@@ -66,8 +66,7 @@ class DirichletMulticlassClassification(Decorator):
         @wraps_class(cls)
         class InnerClass(cls, ClassificationMixin):
             """
-            A wrapper for implementing multiclass GP classification using a Dirichlet
-            transformation.
+            A wrapper for multiclass GP classification using a Dirichlet transformation.
             """
 
             _y_batch_axis = 1


### PR DESCRIPTION
Refs #226

### PR Type
- Documentation content changes

### Description

In classification/dirichlet.py, the docstring for the wrapper InncerClass, in the method _decorate_class() on DirichletMulticlassClassification says:
"""A wrapper for implementing variational inference."""

This looks like a typo. Consider amending to something like:
"""A wrapper for implementing multiclass GP classification using a Dirichlet transformation."""

### How Has This Been Tested?

Existing tests pass as expected.

### Does this PR introduce a breaking change?
 No.

### Screenshots


### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
