### PR TITLE
Replace MIT link with DOI link to fix link checker failure

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -267,7 +267,7 @@
   isbn      = {9780262182539},
   lccn      = {20050533},
   series    = {Adaptive computation and machine learning},
-  url       = {https://direct.mit.edu/books/book/2320/Gaussian-Processes-for-Machine-Learning},
+  url       = {https://doi.org/10.7551/mitpress/3206.001.0001},
   year      = {2006},
   publisher = {MIT Press},
 }


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Bugfix
- CI related changes
- Documentation content changes

### Description
The documentation build is currently failing because the link checker is getting a 403 from https://direct.mit.edu/books/book/2320/Gaussian-Processes-for-Machine-Learning. The link works fine when I access it in a browser, but I think the issue is that they've implemented some kind of javascript-based checker (like cloudflare) that rejects the request. I've tried spoofing the User-Agent header, but this didn't seem to help. 
 
Changing it to a DOI link, which is already ignored by the link checker, bypasses this issue.

### How Has This Been Tested?
Docs builds passes.

### Does this PR introduce a breaking change?
No

### Screenshots
N/A

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
