### PR TITLE
Add newer versions of Python (3.10+) to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -43,6 +43,9 @@ body:
       options:
         - "3.8"
         - "3.9"
+        - "3.10"
+        - "3.11"
+        - "3.12"
     validations:
       required: true
   - type: input


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->


### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

Adds Python versions 3.10-3.12 to the bug report template. Improves bug reporting experience as all development is currently done on Python 3.12, which meant that we couldn't accurately report bugs with the current template.

### How Has This Been Tested?
N/A

### Does this PR introduce a breaking change?
No

### Screenshots
N/A

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [N/A] My code follows the style guidelines of this project.
- [N/A] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [N/A] I have made corresponding changes to the documentation.
- [N/A] My changes generate no new warnings.
- [N/A] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [N/A] Any dependent changes have been merged and published in downstream modules.
