### PR TITLE
Add specific ignores for test warnings, and link TODOs 

### DIFF
--- a/.cspell/custom_misc.txt
+++ b/.cspell/custom_misc.txt
@@ -1,6 +1,5 @@
 colors
 defenses
 docstrings
-favor
 GCHQ
 linted

--- a/.cspell/library_terms.txt
+++ b/.cspell/library_terms.txt
@@ -50,6 +50,7 @@ evals
 evalue
 evecs
 facecolor
+favor
 figsize
 fixsize
 framealpha


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Tests

### Description
Adds specific ignores for each warning that is currently raised by any unit test on 3.12. Many of these are deprecation warnings, and for each of these I've linked an issue. 

See #281 - cataloguing the warnings is a first step to getting rid of them entirely. Doing this via a list of explicit ignores serves two purposes:
 - If new warnings appear, they will be obvious, rather than hidden in a sea of old warnings.
 - It serves as a living checklist of which warnings have been dealt with more appropriately; any where we've been forced to resort to a global disable on more than a temporary basis can be flagged as such.

### How Has This Been Tested?
The tests now raise no warnings, as the warnings have all been suppressed.

### Does this PR introduce a breaking change?
No.

### Screenshots
N/A

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
