### PR TITLE
fix: doctests failing on windows due to dtype differences

### DIFF
--- a/vanguard/classification/categorical.py
+++ b/vanguard/classification/categorical.py
@@ -56,8 +56,8 @@ class CategoricalClassification(Decorator):
         >>>
         >>> test_x = np.array([0.05, 0.95])
         >>> predictions, probs = gp.classify_points(test_x)
-        >>> predictions
-        array([0, 2])
+        >>> predictions.tolist()
+        [0, 2]
     """
 
     def __init__(self, num_classes: int, **kwargs: Any) -> None:

--- a/vanguard/classification/dirichlet.py
+++ b/vanguard/classification/dirichlet.py
@@ -50,8 +50,8 @@ class DirichletMulticlassClassification(Decorator):
         >>>
         >>> test_x = np.array([0.05, 0.5, 0.95])
         >>> predictions, probs = gp.classify_points(test_x)
-        >>> predictions
-        array([0, 1, 2])
+        >>> predictions.tolist()
+        [0, 1, 2]
     """
 
     def __init__(self, num_classes: int, **kwargs: Any) -> None:

--- a/vanguard/classification/kernel.py
+++ b/vanguard/classification/kernel.py
@@ -50,8 +50,8 @@ class DirichletKernelMulticlassClassification(Decorator):
         >>>
         >>> test_x = np.array([0.05, 0.5, 0.95])
         >>> predictions, probs = gp.classify_points(test_x)
-        >>> predictions
-        array([0, 1, 2])
+        >>> predictions.tolist()
+        [0, 1, 2]
     """
 
     def __init__(self, num_classes: int, **kwargs: Any) -> None:


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Documentation content changes
- Tests

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

Use `.tolist()` to fix the dtype issues that were causing these doctests to fail on Windows. Closes #315.

### How Has This Been Tested?

Doctests pass on Windows.

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

No

### Screenshots
<!--
    Include the before and after if your changes include differences in HTML/CSS
-->

N/A

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
