### PR TITLE
tests: quality pass on features.

### DIFF
--- a/tests/units/test_higher_rank_features.py
+++ b/tests/units/test_higher_rank_features.py
@@ -13,7 +13,7 @@ from typing_extensions import Self
 
 from tests.cases import get_default_rng
 from vanguard.datasets.synthetic import HigherRankSyntheticDataset
-from vanguard.features import HigherRankFeatures, _HigherRankFeaturesKernel
+from vanguard.features import HigherRankFeatures
 from vanguard.kernels import ScaledRBFKernel
 from vanguard.standardise import DisableStandardScaling
 from vanguard.vanilla import GaussianGPController
@@ -140,17 +140,3 @@ class BasicTests(unittest.TestCase):
         posterior = self.controller.posterior_over_point(self.dataset.test_x)
         mean, _, _ = posterior.confidence_interval()
         self.assertEqual(mean.shape, self.dataset.test_y.shape)
-
-    def test_kernel_decoration(self) -> None:
-        """Test decoration of a kernel using `_HigherRankFeaturesKernel`."""
-
-        @_HigherRankFeaturesKernel(shape=torch.Size([1, 2, 3]))
-        class HighRankKernel(ScaledRBFKernel):
-            pass
-
-        kernel = HighRankKernel()
-
-        # Evaluate the kernel on some data and verify the output is the correct shape
-        x = torch.ones([1, 2, 3])
-        y = torch.zeros([1, 2, 3])
-        self.assertListEqual(list(kernel(x1=x, x2=y, diag=True).shape), [1, 2])


### PR DESCRIPTION
Refs: 304

### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Tests

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

Test quality pass for high rank features. Note to reviewer:

Inside of `vanguard/features.py`, there is a decorator `_HigherRankFeaturesKernel`. Inside of this, the function `get_vof_basis` is created and currently not covered by tests. Do you have any idea how we access this function, since it's not a method and not returned by the decorator itself?

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

All unittests pass on local machine.

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

N/A

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
