### PR TITLE
fix: bump torch to v2.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,5 @@ six==1.16.0
 sympy==1.12
 threadpoolctl==3.1.0
 torch==2.4.0
-typing_extensions==4.1.1
+typing_extensions==4.12.2
 urllib3==2.2.1


### PR DESCRIPTION
Should fix the "can't find libcudnn.so.8" error

### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Bugfix

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

Should hopefully fix the tests from requirements not being able to find `libcudnn.so.8`.

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

If the requirements tests actually run!

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

PyTorch version is now required to be at least v2.4.0.

### Screenshots
<!--
    Include the before and after if your changes include differences in HTML/CSS
-->

N/A

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
