### PR TITLE
Remove usage of `x.T` for non-2D tensors (use `x.t()` instead)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,8 +163,4 @@ filterwarnings = [
     # TODO: replace with sparse_coo_tensor
     # https://github.com/gchq/Vanguard/issues/278
     "ignore:torch.sparse.SparseTensor\\(indices, values, shape, \\*, device=\\) is deprecated:UserWarning",
-
-    # TODO: investigate
-    # https://github.com/gchq/Vanguard/issues/279
-    "ignore:The use of `x.T` on tensors of dimension other than 2 to reverse their shape is deprecated and it will throw an error in a future release:UserWarning",
 ]

--- a/vanguard/hierarchical/collection.py
+++ b/vanguard/hierarchical/collection.py
@@ -83,7 +83,7 @@ class HyperparameterCollection:
         sigma_0_inv = self._inverse_prior_covariance_matrix
         trace_term = torch.trace(sigma_0_inv @ sigma)
         mean_diff = mu_0 - mu
-        mean_term = mean_diff.T @ sigma_0_inv @ mean_diff
+        mean_term = mean_diff.t() @ sigma_0_inv @ mean_diff
         det_term = torch.log(torch.linalg.det(sigma_0) / torch.linalg.det(sigma))  # pylint: disable=not-callable
 
         return (trace_term + mean_term + det_term - mu.shape[0]) / 2

--- a/vanguard/uncertainty.py
+++ b/vanguard/uncertainty.py
@@ -256,7 +256,7 @@ class GaussianUncertaintyGPController(GPController):
         tx = torch.as_tensor(x, dtype=self.dtype, device=self.device)
         tx_std = self._process_x_std(x_std).to(self.device)
         predictions, covar, additive_grad_noise = self._get_additive_grad_noise(tx, tx_std**2)
-        additional_covar = torch.diag(self._noise_transform(additive_grad_noise).T.reshape(-1))
+        additional_covar = torch.diag(self._noise_transform(additive_grad_noise).t().reshape(-1))
         covar += additional_covar
 
         jitter = torch.eye(covar.shape[0]) * gpytorch.settings.cholesky_jitter.value(covar.dtype)

--- a/vanguard/warps/basefunction.py
+++ b/vanguard/warps/basefunction.py
@@ -261,7 +261,7 @@ class MultitaskWarpFunction(WarpFunction):
         :param y: A stack of input tensors.
         :returns: A stack of tensors in the same shape as stack_of_y.
         """
-        return torch.stack([warp.forward(task_y).squeeze() for warp, task_y in zip(self.warps, y.T)], -1)
+        return torch.stack([warp.forward(task_y).squeeze() for warp, task_y in zip(self.warps, y.t())], -1)
 
     def deriv(self, y: torch.Tensor) -> torch.Tensor:
         """


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Bugfix

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

Closes #279. Use `x.t()` instead of `x.T` when the intention is for 2d tensors to be transposed and for 1d tensors to be left as-is.

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

No more warnings about `x.T` being deprecated for non-2d tensors are raised by any of the tests.

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

No.

### Screenshots
<!--
    Include the before and after if your changes include differences in HTML/CSS
-->

N/A

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
