### PR TITLE
feat: VariationalInference no longer transforms TypeError to ValueError

### DIFF
--- a/tests/units/variational/test_variational.py
+++ b/tests/units/variational/test_variational.py
@@ -40,8 +40,8 @@ class BasicTests(unittest.TestCase):
             )
 
         assert str(ctx.exception) == (
-            "The class passed to ``marginal_log_likelihood_class`` must take a "
-            "``num_data`` :class:`int` argument since we run variational inference with SGD."
+            "The class passed to `marginal_log_likelihood_class` must take a "
+            "`num_data: int` argument, since we run variational inference with SGD."
         )
 
     def test_other_type_error_unaffected(self):

--- a/vanguard/variational/decorator.py
+++ b/vanguard/variational/decorator.py
@@ -157,9 +157,8 @@ class VariationalInference(Decorator, Generic[StrategyT, DistributionT]):
                 except TypeError as error:
                     if "__init__() got an unexpected keyword argument 'num_data'" in str(error):
                         raise TypeError(
-                            "The class passed to ``marginal_log_likelihood_class`` must take a "
-                            "``num_data`` :class:`int` argument since we run "
-                            "variational inference with SGD."
+                            "The class passed to `marginal_log_likelihood_class` must take a "
+                            "`num_data: int` argument, since we run variational inference with SGD."
                         ) from error
                     else:
                         raise


### PR DESCRIPTION
Closes #87

### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Bugfix

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

The error from passing an incorrect marginal log likelihood class to a VariationalInference controller is now a TypeError, not a ValueError.

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

Tests all pass.

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

Yes - the exception class has been changed.

### Screenshots
<!--
    Include the before and after if your changes include differences in HTML/CSS
-->

N/A

### Checklist before requesting a review
- [ ] I have made sure that my PR is not a duplicate.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
