### PR TITLE
fix: don't set GP training data to None in batch mode

### DIFF
--- a/tests/units/test_decorator_combinations.py
+++ b/tests/units/test_decorator_combinations.py
@@ -502,8 +502,8 @@ def _create_decorator(
     [
         pytest.param(None, id="full"),
         # TODO(rg): Many test failures when running with a batch_size set! Often "You must train on the training
-        #  inputs". To be investigated. See for a similar example:
-        # https://github.com/gchq/Vanguard/issues/377
+        #  inputs". To be investigated.
+        # https://github.com/gchq/Vanguard/issues/402
         # pytest.param(2, id="batch"),
     ],
 )

--- a/vanguard/base/basecontroller.py
+++ b/vanguard/base/basecontroller.py
@@ -171,13 +171,8 @@ class BaseGPController:
         class SafeMarginalLogLikelihoodClass(marginal_log_likelihood_class):
             pass
 
-        if self.batch_size is not None:
-            # then the training data will be updated at each training iteration
-            gp_train_x = None
-            gp_train_y = None
-        else:
-            gp_train_x = self.train_x
-            gp_train_y = self.train_y.squeeze(dim=-1)
+        gp_train_x = self.train_x
+        gp_train_y = self.train_y.squeeze(dim=-1)
 
         self._gp = SafeGPModelClass(
             gp_train_x,


### PR DESCRIPTION
Fixes #377

### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Bugfix

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

Previously (since #354) we set the training data to None initially when doing batch mode training. However, this causes an issue with some decorators (notably VariationalInference), as they need to examine the training data before fitting starts. Now, training data is initially set to the full training data.

This doesn't resolve _all_ the batch mode issues, but does at least resolve #377.

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

The snippet from #377 now passes. (Using `DATASET = MultidimensionalSyntheticDataset([simple_f] * 13, n_train_points=450, n_test_points=450)` instead of the bike dataset.)

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

No


### Checklist before requesting a review
- [ ] I have made sure that my PR is not a duplicate.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
