### PR TITLE
chore: pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ default_stages:
   - pre-merge-commit
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       # Reject commits that add large files (coverage.xml, for example)
       # Consider adjusting kB limit
@@ -59,7 +59,7 @@ repos:
       # No tabs, only spaces
       - id: forbid-tabs
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.1
+    rev: v0.7.0
     hooks:
       # Run the formatter.
       - id: ruff-format
@@ -78,7 +78,7 @@ repos:
       # Ensure that necessary package information is provided
       - id: pyroma
   - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v8.13.3
+    rev: v8.15.2
     hooks:
       # Run a spellcheck (words pulled from cspell.config.yaml)
         - id: cspell


### PR DESCRIPTION
[https://github.com/pre-commit/pre-commit-hooks] updating v4.6.0 -> v5.0.0
[https://github.com/astral-sh/ruff-pre-commit] updating v0.6.1 -> v0.7.0
[https://github.com/streetsidesoftware/cspell-cli] updating v8.13.3 -> v8.15.2
