### PR TITLE
fix: requirements_doc_path

### DIFF
--- a/.github/workflows/uv_lock_autoupdate.yml
+++ b/.github/workflows/uv_lock_autoupdate.yml
@@ -9,7 +9,7 @@ jobs:
   uv_lock_autoupdate:
     env:
       lockfile_path: uv.lock
-      requirements_doc_path: requirements-doc.txt
+      requirements_doc_path: requirements-docs.txt
       update_message_path: /tmp/message.txt
       update_branch: chore/uv-lock-autoupdate
     runs-on: ubuntu-latest


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Bugfix
- CI related changes


### Description

The uv_lock_autoupdate workflow is failing due to a typo in .github/workflows/uv_lock_autoupdate.yml. 

The variable `requirements_doc_path` was `requirements-doc.txt`, when it should be `requirements-docs.txt`. 

### How Has This Been Tested?

n/a

### Does this PR introduce a breaking change?

No.

### Screenshots


### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
