### PR TITLE
Initial rework of decorator warnings

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Debug - uv pip freeze
         run: uv pip freeze
       - name: Assess coverage of unit tests
-        run: uv run pytest tests/units --cov
+        run: uv run pytest tests/units tests/test_doctests.py --cov
       - name: Extract total coverage percentage
         id: cov
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ Version 4 will be the first stable version.
 
 ### Changed
 
--
+- Reduced the number of spurious `OverwrittenMethodWarning`s and `UnexpectedMethodWarning`s raised by normal usage.
+   (https://github.com/gchq/Vanguard/pull/515)
 
 ### Removed
 

--- a/tests/units/decoratorutils/test_basedecorator.py
+++ b/tests/units/decoratorutils/test_basedecorator.py
@@ -327,11 +327,13 @@ class TestErrorsWhenOverwriting:
 
             if mode == "new_method":
                 expected_message = (
-                    f"The class '{blame_class}' has added the following unexpected methods: {{'something_new'}}."
+                    f"{SquareResult.__name__!r}: The class '{blame_class}' has added the following unexpected methods"
                 )
                 expected_types = errors.UnexpectedMethodError, errors.UnexpectedMethodWarning
             elif mode == "override_method":
-                expected_message = f"The class '{blame_class}' has overwritten the following methods: {{'add_5'}}."
+                expected_message = (
+                    f"{SquareResult.__name__!r}: The class '{blame_class}' has overwritten the following methods"
+                )
                 expected_types = errors.OverwrittenMethodError, errors.OverwrittenMethodWarning
             else:
                 raise ValueError(mode)

--- a/tests/units/test_decorator_combinations.py
+++ b/tests/units/test_decorator_combinations.py
@@ -30,7 +30,7 @@ from gpytorch.means import ZeroMean
 from gpytorch.mlls import VariationalELBO
 from typing_extensions import TypedDict
 
-from tests.cases import get_default_rng, maybe_throws, maybe_warns
+from tests.cases import assert_not_warns, get_default_rng, maybe_throws, maybe_warns
 
 # not super happy about importing HigherRankKernel/HigherRankMean from another test file - these should probably be
 # moved to some more central location
@@ -50,7 +50,7 @@ from vanguard.datasets import Dataset
 from vanguard.datasets.classification import MulticlassGaussianClassificationDataset
 from vanguard.datasets.synthetic import HigherRankSyntheticDataset, SyntheticDataset, complicated_f, simple_f
 from vanguard.decoratorutils import Decorator, TopMostDecorator
-from vanguard.decoratorutils.errors import BadCombinationWarning
+from vanguard.decoratorutils.errors import BadCombinationWarning, OverwrittenMethodWarning, UnexpectedMethodWarning
 from vanguard.distribute import Distributed
 from vanguard.features import HigherRankFeatures
 from vanguard.hierarchical import (
@@ -705,3 +705,18 @@ def test_combinations(
         # the minimum number that doesn't cause numerical errors.
         with patch.object(MonteCarloPosteriorCollection, "_decide_mc_num_samples", lambda *_: 4):
             fuzzy_posterior.confidence_interval(dataset.significance)
+
+
+def test_no_overwrite_warnings_temporary():
+    """
+    Test that no spurious warnings are raised on decorator application in simple cases.
+
+    This is a temporary test, and should be incorporated into test_combinations above once all decorators have this
+    set up.
+    """
+
+    class BinaryClassifier(GaussianGPController):
+        pass
+
+    with assert_not_warns(OverwrittenMethodWarning), assert_not_warns(UnexpectedMethodWarning):
+        BinaryClassification()(VariationalInference()(BinaryClassifier))

--- a/vanguard/classification/binary.py
+++ b/vanguard/classification/binary.py
@@ -92,7 +92,9 @@ class BinaryClassification(Decorator):
         super().__init__(framework_class=GPController, required_decorators={VariationalInference}, **kwargs)
 
     def _decorate_class(self, cls: type[ControllerT]) -> type[ControllerT]:
-        @Classification()
+        @Classification(
+            ignore_all=self.ignore_all, ignore_methods=self.ignore_methods, raise_instead=self.raise_instead
+        )
         @wraps_class(cls)
         class InnerClass(cls, ClassificationMixin):
             """

--- a/vanguard/classification/binary.py
+++ b/vanguard/classification/binary.py
@@ -23,6 +23,7 @@ import numpy.typing
 import torch
 from gpytorch.likelihoods import BernoulliLikelihood
 from torch import Tensor
+from typing_extensions import override
 
 from vanguard import utils
 from vanguard.base import GPController
@@ -91,11 +92,19 @@ class BinaryClassification(Decorator):
         """
         super().__init__(framework_class=GPController, required_decorators={VariationalInference}, **kwargs)
 
-    def _decorate_class(self, cls: type[ControllerT]) -> type[ControllerT]:
-        @Classification(
-            ignore_all=self.ignore_all, ignore_methods=self.ignore_methods, raise_instead=self.raise_instead
+    @property
+    @override
+    def safe_updates(self) -> dict[type, set[str]]:
+        return self._add_to_safe_updates(
+            super().safe_updates,
+            {VariationalInference: {"__init__", "_predictive_likelihood", "_fuzzy_predictive_likelihood"}},
         )
-        @wraps_class(cls)
+
+    def _decorate_class(self, cls: type[ControllerT]) -> type[ControllerT]:
+        # We set ignore_all here as it doesn't make sense for @Classification to be checking for overrides - that
+        # should only be done by decorators that actually add mathematical changes
+        @Classification(ignore_all=True)
+        @wraps_class(cls, decorator_source=self)
         class InnerClass(cls, ClassificationMixin):
             """
             A wrapper for implementing binary classification.

--- a/vanguard/classification/mixin.py
+++ b/vanguard/classification/mixin.py
@@ -120,7 +120,7 @@ class Classification(Decorator):
     def _decorate_class(self, cls: type[T]) -> type[T]:
         """Close off the prediction methods on a GP."""
 
-        @wraps_class(cls)
+        @wraps_class(cls, decorator_source=self)
         class InnerClass(cls):
             """Class that closes off the prediction methods."""
 

--- a/vanguard/decoratorutils/basedecorator.py
+++ b/vanguard/decoratorutils/basedecorator.py
@@ -288,6 +288,7 @@ class Decorator:
             outer_class = mro_unwrapped[method_path[0]]
         except KeyError:
             # TODO: logging here?
+            # https://github.com/gchq/Vanguard/issues/123
             return None
 
         if len(method_path) == 2:
@@ -307,6 +308,7 @@ class Decorator:
             return outer_class.__vanguard_wrap_source__.__class__
         else:
             # TODO: logging here?
+            # https://github.com/gchq/Vanguard/issues/123
             return None
 
 

--- a/vanguard/decoratorutils/basedecorator.py
+++ b/vanguard/decoratorutils/basedecorator.py
@@ -152,7 +152,10 @@ class Decorator:
         extra_methods = cls_methods - super_methods - ignore_methods
         if extra_methods:
             if __debug__:
-                message = f"The class {cls.__name__!r} has added the following unexpected methods: {extra_methods!r}."
+                message = (
+                    f"{self.__class__.__name__!r}: The class {cls.__name__!r} "
+                    f"has added the following unexpected methods: {extra_methods!r}."
+                )
             else:
                 message = "Unexpected methods added to the class"
             if self.raise_instead:
@@ -163,7 +166,10 @@ class Decorator:
         overwritten_methods = {method for method in cls_methods if method in cls.__dict__} - ignore_methods
         if overwritten_methods:
             if __debug__:
-                message = f"The class {cls.__name__!r} has overwritten the following methods: {overwritten_methods!r}."
+                message = (
+                    f"{self.__class__.__name__!r}: The class {cls.__name__!r} "
+                    f"has overwritten the following methods: {overwritten_methods!r}."
+                )
             else:
                 message = "Unexpected methods overwritten by the class"
             if self.raise_instead:

--- a/vanguard/decoratorutils/basedecorator.py
+++ b/vanguard/decoratorutils/basedecorator.py
@@ -19,7 +19,7 @@ Contains the BaseDecorator class.
 import warnings
 from collections.abc import Iterable
 from inspect import getmembers, isfunction
-from typing import TypeVar
+from typing import Optional, TypeVar
 
 from vanguard.decoratorutils import errors
 
@@ -97,6 +97,42 @@ class Decorator:
             decorated_class.__decorators__ = decorated_class.__decorators__ + [type(self)]
         return decorated_class
 
+    @property
+    def safe_updates(self) -> dict[type, set[str]]:
+        """Get a dictionary (class -> set[names]) of overrides/new methods that we consider "safe"."""
+        # This import needs to be lazy to avoid circular imports.
+        from vanguard.vanilla import GaussianGPController  # pylint: disable=import-outside-toplevel
+
+        return {GaussianGPController: {"__init__"}}
+
+    @staticmethod
+    def _add_to_safe_updates(old: dict[type, set[str]], new: dict[type, set[str]]) -> dict[type, set[str]]:
+        """
+        Add to a safe-updates set in-place - see the example.
+
+        :Example:
+            >>> class A: pass
+            >>> class B: pass
+            >>> class C: pass
+            >>> old = {A: {"1", "2"}, B: {"other"}}
+            >>> new = {A: {"3"}, C: {"newer"}}
+            >>> updated = Decorator._add_to_safe_updates(old, new)
+            >>> sorted(updated[A])  # sets are updated
+            ['1', '2', '3']
+            >>> updated[B]  # non-overlapping keys are both added
+            {'other'}
+            >>> updated[C]
+            {'newer'}
+            >>> updated == old  # `old` is modified in-place
+            True
+        """
+        for key, value in new.items():
+            if key in old:
+                old[key].update(value)
+            else:
+                old[key] = value
+        return old
+
     def _decorate_class(self, cls: type[T]) -> type[T]:
         """Return a wrapped version of a class."""
         return cls
@@ -146,15 +182,28 @@ class Decorator:
         :raises errors.OverwrittenMethodError: If a method has been overwritten, and the
             :attr:`vanguard.decoratorutils.basedecorator.Decorator.raise_instead` is ``True``.
         """
-        cls_methods = {key for key, value in getmembers(cls) if isfunction(value)}
+        cls_methods = {
+            key
+            for key, value in getmembers(cls, isfunction)
+            if key not in self.safe_updates.get(self._get_method_implementation(cls, key), set())
+        }
         ignore_methods = set(self.ignore_methods) | {"__wrapped__"}
 
         extra_methods = cls_methods - super_methods - ignore_methods
         if extra_methods:
             if __debug__:
+                extra_method_messages = "\n".join(
+                    f"* {getattr(cls, method).__vanguard_wrap_source__.__class__.__module__}"
+                    f".{getattr(cls, method).__vanguard_wrap_source__.__class__.__qualname__}.{method} "
+                    f"(wrapping {getattr(cls, method).__module__}.{getattr(cls, method).__qualname__})"
+                    if hasattr(getattr(cls, method), "__vanguard_wrap_source__")
+                    else f"* {getattr(cls, method).__module__}.{getattr(cls, method).__qualname__}"
+                    for method in extra_methods
+                )
                 message = (
                     f"{self.__class__.__name__!r}: The class {cls.__name__!r} "
-                    f"has added the following unexpected methods: {extra_methods!r}."
+                    f"has added the following unexpected methods: \n"
+                    f"{extra_method_messages}"
                 )
             else:
                 message = "Unexpected methods added to the class"
@@ -166,9 +215,18 @@ class Decorator:
         overwritten_methods = {method for method in cls_methods if method in cls.__dict__} - ignore_methods
         if overwritten_methods:
             if __debug__:
+                overwritten_method_messages = "\n".join(
+                    f"* {getattr(cls, method).__vanguard_wrap_source__.__class__.__module__}"
+                    f".{getattr(cls, method).__vanguard_wrap_source__.__class__.__qualname__}.{method} "
+                    f"(wrapping {getattr(cls, method).__module__}.{getattr(cls, method).__qualname__})"
+                    if hasattr(getattr(cls, method), "__vanguard_wrap_source__")
+                    else f"* {getattr(cls, method).__module__}.{getattr(cls, method).__qualname__}"
+                    for method in overwritten_methods
+                )
                 message = (
                     f"{self.__class__.__name__!r}: The class {cls.__name__!r} "
-                    f"has overwritten the following methods: {overwritten_methods!r}."
+                    f"has overwritten the following methods: \n"
+                    f"{overwritten_method_messages}"
                 )
             else:
                 message = "Unexpected methods overwritten by the class"
@@ -176,6 +234,80 @@ class Decorator:
                 raise errors.OverwrittenMethodError(message)
             else:
                 warnings.warn(message, errors.OverwrittenMethodWarning)
+
+    @staticmethod
+    def _get_method_implementation(subclass: type, method_name: str) -> Optional[type]:
+        """
+        Get the class that provides the implementation of a method.
+
+        Has a special case for classes decorated with @wraps_class.
+
+        This is doing some rather finicky introspection, so might end up being quite fragile.
+
+        In particular, things that might cause problems are:
+
+          - Classes that inherit from a wrapped class.
+          - Nested classes.
+
+        :Example:
+            >>> from vanguard.vanilla import GaussianGPController
+            >>> Decorator._get_method_implementation(GaussianGPController, "__init__").__name__
+            'GaussianGPController'
+            >>> Decorator._get_method_implementation(GaussianGPController, "fit").__name__
+            'GPController'
+            >>> Decorator._get_method_implementation(GaussianGPController, "_predictive_likelihood").__name__
+            'BaseGPController'
+
+        :Example:
+            >>> from vanguard.classification import BinaryClassification
+            >>> from vanguard.variational import VariationalInference
+            >>> from vanguard.vanilla import GaussianGPController
+            >>> @BinaryClassification()
+            ... @VariationalInference()
+            ... class BinaryController(GaussianGPController):
+            ...     pass
+            >>> Decorator._get_method_implementation(BinaryController, "classify_points").__name__
+            'BinaryClassification'
+
+
+        :param subclass: The class that the method belongs to. (Note that this could be a subclass.)
+        :param method_name: The name of the method to get the implementing class for.
+        :returns: The class that provides the implementation for the method, or None if the class could not be found.
+        """
+        method = getattr(subclass, method_name)
+        # Handle wrapping by @wraps_class
+        if hasattr(method, "__vanguard_wrap_source__"):
+            return getattr(method, "__vanguard_wrap_source__").__class__
+
+        method_path = method.__qualname__.split(".")
+        mro_unwrapped = {
+            (c.__vanguard_wrap_source__.__class__.__name__ if hasattr(c, "__vanguard_wrap_source__") else c.__name__): c
+            for c in subclass.__mro__
+        }
+        try:
+            outer_class = mro_unwrapped[method_path[0]]
+        except KeyError:
+            # TODO: logging here?
+            return None
+
+        if len(method_path) == 2:
+            # Simple case - Class.method()
+            return outer_class
+        if (
+            # Vanguard decorator case: DecoratorClass._decorate_class.<locals>.InnerClass.method()
+            hasattr(outer_class, "__vanguard_wrap_source__")
+            and isinstance(outer_class.__vanguard_wrap_source__, Decorator)
+            and len(method_path) == 5
+            # method_path[0] is the class name
+            and method_path[1] == "_decorate_class"
+            and method_path[2] == "<locals>"
+            # method_path[3] is conventionally `InnerClass`, but don't enforce this
+            # method_path[4] is the method_name
+        ):
+            return outer_class.__vanguard_wrap_source__.__class__
+        else:
+            # TODO: logging here?
+            return None
 
 
 class TopMostDecorator(Decorator):

--- a/vanguard/variational/decorator.py
+++ b/vanguard/variational/decorator.py
@@ -137,7 +137,7 @@ class VariationalInference(Decorator, Generic[StrategyT, DistributionT]):
         decorator = self
         _gp_model_class = self.gp_model_class
 
-        @wraps_class(cls)
+        @wraps_class(cls, decorator_source=self)
         class InnerClass(cls):
             """
             A wrapper for implementing variational inference.


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Feature

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

Decorators now check against a known "safe list" of overrides and new methods before raising a warning. This should reduce the number of spurious warnings that end users see. So far this has only been implemented for `BinaryClassification` above `VariationalInference`; expanding this to other decorators is left to future PRs.

Also improves the warning messages when they are raised, making it clearer exactly where the problem is coming from.

Progresses #123 but does not close it.

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

Existing tests all pass. Added a temporary test to `test_decorator_combinations` to check that no spurious warnings are raised; this test should be incorporated into the general combinations test once implemented for all decorators.

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

No.


### Checklist before requesting a review
- [ ] I have made sure that my PR is not a duplicate.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
