### PR TITLE
Add framework for testing for decorator warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,12 +245,6 @@ filterwarnings = [
     "ignore:You have passed data through a FixedNoiseGaussianLikelihood that did not match the size of the fixed noise:gpytorch.utils.warnings.GPInputWarning",
     "ignore:To get the last learning rate computed by the scheduler, please use `get_last_lr\\(\\)`:UserWarning",
 
-    # Vanguard being pedantic errors
-    # TODO: add ignore_methods to fix these
-    # https://github.com/gchq/Vanguard/issues/283
-    "ignore::vanguard.decoratorutils.errors.OverwrittenMethodWarning",
-    "ignore::vanguard.decoratorutils.errors.UnexpectedMethodWarning",
-
     # -- Deprecations --
     # TODO: replace with sparse_coo_tensor
     # https://github.com/gchq/Vanguard/issues/278

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -19,6 +19,7 @@ Contains test cases for Vanguard testing.
 import contextlib
 import unittest
 import warnings
+from collections.abc import Iterable
 from typing import Any, Optional, Union
 from unittest.mock import Mock
 
@@ -196,12 +197,19 @@ class VanguardTestCase(unittest.TestCase):
 
 
 @contextlib.contextmanager
-def assert_not_warns(expected_warning_type: type[Warning] = Warning) -> None:
-    """Assert that enclosed code raises no warnings, or no warnings of a given type."""
+def assert_not_warns(*expected_warning_types: type[Warning]) -> Iterable[None]:
+    r"""
+    Assert that enclosed code raises no warnings, or no warnings of a given type.
+
+    :param \*expected_warning_types: Warning types to check for. If none are provided, checks for all types of warnings.
+    """
     with warnings.catch_warnings(record=True) as ws:
         yield
 
-    ws = list(filter(lambda w: issubclass(w.category, expected_warning_type), ws))
+    if expected_warning_types:
+        ws = list(
+            filter(lambda w: any(issubclass(w.category, warning_type) for warning_type in expected_warning_types), ws)
+        )
 
     if len(ws) > 0:
         msg = f"Expected no warnings, caught {len(ws)}: {[w.message for w in ws]}"

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -201,15 +201,27 @@ def assert_not_warns(*expected_warning_types: type[Warning]) -> Iterable[None]:
     r"""
     Assert that enclosed code raises no warnings, or no warnings of a given type.
 
+    If a warning type is provided, this context manager re-raises any warnings that were not of the given type, with
+    the same message, but with stacklevel=1. This loses information as to where the warning originally came from, but
+    handling this more intelligently would require fiddling with the guts of the :mod:`warnings` module.
+
     :param \*expected_warning_types: Warning types to check for. If none are provided, checks for all types of warnings.
     """
     with warnings.catch_warnings(record=True) as ws:
         yield
 
     if expected_warning_types:
-        ws = list(
-            filter(lambda w: any(issubclass(w.category, warning_type) for warning_type in expected_warning_types), ws)
-        )
+        # Filter to only warnings of the given types; re-raise warnings not of that type
+        ws_caught = []
+        ws_uncaught = []
+        for warning in ws:
+            if any(issubclass(warning.category, warning_type) for warning_type in expected_warning_types):
+                ws_caught.append(warning)
+            else:
+                ws_uncaught.append(warning)
+        for warning in ws_uncaught:
+            warnings.warn(message=warning.message, category=warning.category, stacklevel=1, source=warning.source)
+        ws = ws_caught
 
     if len(ws) > 0:
         msg = f"Expected no warnings, caught {len(ws)}: {[w.message for w in ws]}"

--- a/tests/units/meta/test_test_extras.py
+++ b/tests/units/meta/test_test_extras.py
@@ -49,7 +49,7 @@ class TestNotWarns:
 
     def test_passes_with_warning_not_of_given_type(self):
         """Test that if a warning type is passed, warnings not of that type do not cause any error."""
-        with assert_not_warns(UserWarning):
+        with pytest.warns(OtherWarningSubclass), assert_not_warns(UserWarning):
             warnings.warn("A warning!", OtherWarningSubclass)
 
     def test_fails_with_warning_of_given_type(self):
@@ -73,5 +73,11 @@ class TestNotWarns:
 
     def test_passes_with_warning_not_of_given_types(self):
         """Test that if a warning not of either of the given types is raised, it does not cause any error."""
-        with assert_not_warns(SubclassOfUserWarning, SecondSubclassOfUserWarning):
+        with pytest.warns(OtherWarningSubclass), assert_not_warns(SubclassOfUserWarning, SecondSubclassOfUserWarning):
             warnings.warn("A warning!", OtherWarningSubclass)
+
+    def test_nested(self):
+        """Test that nesting multiple copies of assert_not_warns works."""
+        with pytest.raises(AssertionError):
+            with assert_not_warns(OtherWarningSubclass), assert_not_warns(UserWarning):
+                warnings.warn("A warning!", OtherWarningSubclass)

--- a/tests/units/meta/test_test_extras.py
+++ b/tests/units/meta/test_test_extras.py
@@ -29,6 +29,10 @@ class SubclassOfUserWarning(UserWarning):
     """Warning subclass used for testing."""
 
 
+class SecondSubclassOfUserWarning(UserWarning):
+    """Warning subclass used for testing."""
+
+
 class TestNotWarns:
     """Tests for the assert_not_warns() context manager."""
 
@@ -59,3 +63,15 @@ class TestNotWarns:
         with pytest.raises(AssertionError):
             with assert_not_warns(UserWarning):
                 warnings.warn("A warning!", SubclassOfUserWarning)
+
+    @pytest.mark.parametrize("warning_class", [SubclassOfUserWarning, SecondSubclassOfUserWarning])
+    def test_fails_with_either_of_multiple_warnings(self, warning_class: type[Warning]):
+        """Test usage of assert_not_warns with multiple warning types."""
+        with pytest.raises(AssertionError):
+            with assert_not_warns(SubclassOfUserWarning, SecondSubclassOfUserWarning):
+                warnings.warn("A warning!", warning_class)
+
+    def test_passes_with_warning_not_of_given_types(self):
+        """Test that if a warning not of either of the given types is raised, it does not cause any error."""
+        with assert_not_warns(SubclassOfUserWarning, SecondSubclassOfUserWarning):
+            warnings.warn("A warning!", OtherWarningSubclass)

--- a/tests/units/test_decorator_combinations.py
+++ b/tests/units/test_decorator_combinations.py
@@ -17,6 +17,7 @@ Tests for the pairwise combinations of decorators.
 """
 
 import itertools
+from contextlib import nullcontext
 from typing import Any, Optional, TypeVar
 from unittest.mock import patch
 
@@ -105,7 +106,7 @@ class RequirementDetails(TypedDict, total=False):
     """Type hint for the sub-decorator details specification in `DECORATORS`."""
 
     decorator: dict[str, Any]
-    """Keyword arguments to pass to the decorator. `ignore_all=True` is always passed."""
+    """Keyword arguments to pass to the decorator."""
     controller: dict[str, Any]
     """Additional keyword arguments to pass to the `GPController` on instantiation."""
 
@@ -114,7 +115,7 @@ class DecoratorDetails(TypedDict, total=False):
     """Type hint for the decorator details specifications in `DECORATORS`."""
 
     decorator: dict[str, Any]
-    """Keyword arguments to pass to the decorator. `ignore_all=True` is always passed."""
+    """Keyword arguments to pass to the decorator."""
     controller: dict[str, Any]
     """Additional keyword arguments to pass to the `GPController` on instantiation."""
     dataset: Dataset
@@ -406,6 +407,9 @@ DATASET_CONFLICT_OVERRIDES = {
     }
 }
 
+# Decorators which shouldn't raise `OverwrittenMethodWarning` or `UnexpectedMethodWarning` when used together.
+HAS_SUPPRESSED_WARNINGS = {EmptyDecorator}
+
 
 def _initialise_decorator_pair(
     upper_decorator_details: tuple[type[Decorator], DecoratorDetails],
@@ -505,7 +509,7 @@ def _create_decorator(
         - `dataset`: dataset to test with, or :data:`None` to defer to the other decorator or to a default
     """
     decorator_class, decorator_details = details
-    decorator = decorator_class(ignore_all=True, **decorator_details.get("decorator", {}))
+    decorator = decorator_class(**decorator_details.get("decorator", {}))
     controller_kwargs = {}
 
     requirement_decorators = []
@@ -591,7 +595,19 @@ def test_combinations(
         combination, (None, None)
     )
     expected_error_class, expected_error_message = EXPECTED_COMBINATION_APPLY_ERRORS.get(combination, (None, None))
+    if (
+        expected_error_class is None
+        and expected_warning_class is None
+        and any(isinstance(upper_decorator, cls) for cls in HAS_SUPPRESSED_WARNINGS)
+        and any(isinstance(lower_decorator, cls) for cls in HAS_SUPPRESSED_WARNINGS)
+    ):
+        # If *both* upper and lower decorator have suppressed warnings, we shouldn't get any of these spurious warnings.
+        # However, if we expect some other error or warning, don't bother to check.
+        warnings_context = assert_not_warns(OverwrittenMethodWarning, UnexpectedMethodWarning)
+    else:
+        warnings_context = nullcontext()
     with (
+        warnings_context,
         maybe_warns(expected_warning_class, expected_warning_message),
         maybe_throws(expected_error_class, expected_error_message),
     ):
@@ -718,5 +734,5 @@ def test_no_overwrite_warnings_temporary():
     class BinaryClassifier(GaussianGPController):
         pass
 
-    with assert_not_warns(OverwrittenMethodWarning), assert_not_warns(UnexpectedMethodWarning):
+    with assert_not_warns(OverwrittenMethodWarning, UnexpectedMethodWarning):
         BinaryClassification()(VariationalInference()(BinaryClassifier))

--- a/tests/units/test_features.py
+++ b/tests/units/test_features.py
@@ -123,7 +123,7 @@ class HigherRankMean(ConstantMean):
         return super().forward(input.reshape(input.shape[0], 4))
 
 
-@HigherRankFeatures(2)
+@HigherRankFeatures(2, ignore_all=True)
 @DisableStandardScaling(ignore_all=True)
 class Rank2Controller(GaussianGPController):
     pass

--- a/vanguard/decoratorutils/basedecorator.py
+++ b/vanguard/decoratorutils/basedecorator.py
@@ -186,6 +186,10 @@ class Decorator:
             key
             for key, value in getmembers(cls, isfunction)
             if key not in self.safe_updates.get(self._get_method_implementation(cls, key), set())
+            # beartype does weird things with __sizeof__; however, it's of no concern to us, and we never make use of
+            # this dunder attribute. See https://github.com/beartype/beartype/blob/v0.19.0/beartype/_decor/_decortype.py
+            # for more details
+            and key != "__sizeof__"
         }
         ignore_methods = set(self.ignore_methods) | {"__wrapped__"}
 

--- a/vanguard/decoratorutils/basedecorator.py
+++ b/vanguard/decoratorutils/basedecorator.py
@@ -210,7 +210,7 @@ class Decorator:
             if self.raise_instead:
                 raise errors.UnexpectedMethodError(message)
             else:
-                warnings.warn(message, errors.UnexpectedMethodWarning)
+                warnings.warn(message, errors.UnexpectedMethodWarning, stacklevel=4)
 
         overwritten_methods = {method for method in cls_methods if method in cls.__dict__} - ignore_methods
         if overwritten_methods:
@@ -233,7 +233,7 @@ class Decorator:
             if self.raise_instead:
                 raise errors.OverwrittenMethodError(message)
             else:
-                warnings.warn(message, errors.OverwrittenMethodWarning)
+                warnings.warn(message, errors.OverwrittenMethodWarning, stacklevel=4)
 
     @staticmethod
     def _get_method_implementation(subclass: type, method_name: str) -> Optional[type]:


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Tests

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

Adds a new set `HAS_SUPPRESSED_WARNINGS` to `test_decorator_combinations` which tracks those decorators that should not raise warnings in normal use. If a decorator combination is not expected to raise any other warnings or errors on decorator application, and both the upper and lower decorator are listed in `HAS_SUPPRESSED_WARNINGS`, then the test also asserts that applying both decorators doesn't raise any `OverwrittenMethodWarning` or `UnexpectedMethodWarning`. 

Also contains improvements to `assert_not_warns`.

Closes #523.

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

Tests all still pass, but fail if more decorators are added to `HAS_SUPPRESSED_WARNINGS` (as expected).

Added new tests for the new features of `assert_not_warns`.

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

No.

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings - A lot of new warnings are generated, as I've disabled the suppression of `OverwrittenMethodWarning` and `UnexpectedMethodWarning` in the tests in order for the tests for those warnings to work.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
