### PR TITLE
fix: classification decorator warnings

### DIFF
--- a/tests/cases.py
+++ b/tests/cases.py
@@ -224,7 +224,8 @@ def assert_not_warns(*expected_warning_types: type[Warning]) -> Iterable[None]:
         ws = ws_caught
 
     if len(ws) > 0:
-        msg = f"Expected no warnings, caught {len(ws)}: {[w.message for w in ws]}"
+        sep = "\n-----------\n"
+        msg = f"Expected no warnings, caught {len(ws)}: {sep.join([f'{w.category.__name__}: {w.message}' for w in ws])}"
         if __debug__:
             raise AssertionError(msg)
         else:

--- a/tests/units/test_decorator_combinations.py
+++ b/tests/units/test_decorator_combinations.py
@@ -141,7 +141,12 @@ class EmptyDecorator(Decorator):
     """Placeholder decorator to allow testing each other decorator on its own."""
 
     def __init__(self, **kwargs) -> None:
-        """Initialise the placeholder decorator."""
+        """
+        Initialise the placeholder decorator.
+
+        `ignore_all=True` is always passed, since this decorator is meant to be a no-op.
+        """
+        kwargs["ignore_all"] = True
         super().__init__(framework_class=GPController, required_decorators={}, **kwargs)
 
     def _decorate_class(self, cls: T) -> T:
@@ -408,7 +413,13 @@ DATASET_CONFLICT_OVERRIDES = {
 }
 
 # Decorators which shouldn't raise `OverwrittenMethodWarning` or `UnexpectedMethodWarning` when used together.
-HAS_SUPPRESSED_WARNINGS = {EmptyDecorator}
+HAS_SUPPRESSED_WARNINGS = {
+    EmptyDecorator,
+    BinaryClassification,
+    CategoricalClassification,
+    DirichletKernelMulticlassClassification,
+    DirichletMulticlassClassification,
+}
 
 
 def _initialise_decorator_pair(
@@ -723,16 +734,19 @@ def test_combinations(
             fuzzy_posterior.confidence_interval(dataset.significance)
 
 
-def test_no_overwrite_warnings_temporary():
+def test_no_overwrite_warnings_classifiers_temporary():
     """
-    Test that no spurious warnings are raised on decorator application in simple cases.
+    Test that no spurious warnings are raised on decorator application in simple cases with classifiers.
 
     This is a temporary test, and should be incorporated into test_combinations above once all decorators have this
     set up.
     """
 
-    class BinaryClassifier(GaussianGPController):
+    class TestController(GaussianGPController):
         pass
 
     with assert_not_warns(OverwrittenMethodWarning, UnexpectedMethodWarning):
-        BinaryClassification()(VariationalInference()(BinaryClassifier))
+        BinaryClassification()(VariationalInference()(TestController))
+        CategoricalClassification(num_classes=3)(Multitask(num_tasks=3)(VariationalInference()(TestController)))
+        DirichletMulticlassClassification(num_classes=3)(TestController)
+        DirichletKernelMulticlassClassification(num_classes=3)(TestController)

--- a/vanguard/classification/kernel.py
+++ b/vanguard/classification/kernel.py
@@ -85,8 +85,8 @@ class DirichletKernelMulticlassClassification(Decorator):
     def _decorate_class(self, cls: type[ControllerT]) -> type[ControllerT]:
         num_classes = self.num_classes
 
-        @Classification()
-        @wraps_class(cls)
+        @Classification(ignore_all=True)
+        @wraps_class(cls, decorator_source=self)
         class InnerClass(cls, ClassificationMixin):
             gp_model_class = InertKernelModel
 

--- a/vanguard/classification/mixin.py
+++ b/vanguard/classification/mixin.py
@@ -28,6 +28,7 @@ from typing import NoReturn, TypeVar, Union
 
 import numpy as np
 import numpy.typing
+from typing_extensions import override
 
 from vanguard.base import GPController
 from vanguard.decoratorutils import Decorator, wraps_class
@@ -116,6 +117,14 @@ class Classification(Decorator):
                     "Please use only one classification decorator at once."
                 )
                 raise TypeError(msg)
+
+    @property
+    @override
+    def safe_updates(self) -> dict[type, set[str]]:
+        return self._add_to_safe_updates(
+            super().safe_updates,
+            {ClassificationMixin: {"classify_points", "classify_fuzzy_points"}},
+        )
 
     def _decorate_class(self, cls: type[T]) -> type[T]:
         """Close off the prediction methods on a GP."""


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Feature
- Tests

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

Closes #518. Note that `VariationalInference` has _not_ been added to `HAS_SUPPRESSED_WARNINGS` since it still has a large number of warnings - these stem from the fact that the `VariationalInference` decorator is applied multiple times, which I'm not sure we want to support. IMO we should check for this and raise a warning, but I think that might be out of scope for this PR.

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

New temporary test has been added. Classification decorators have been added to `HAS_SUPPRESSED_WARNINGS` so this is tested as part of `test_decorator_combinations` as well.

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

No.

### Checklist before requesting a review
- [ ] I have made sure that my PR is not a duplicate.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
