### PR TITLE
fix: all remaining decorator warnings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ For a full list see the documentation: https://www.sphinx-doc.org/en/master/usag
 import logging
 
 # a bunch of pylint disables as this file is uniquely weird:
-# pylint: disable=import-error,invalid-name,wrong-import-order,wrong-import-position
+# pylint: disable=invalid-name,wrong-import-order,wrong-import-position
 import os
 import re
 import shutil

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -230,3 +230,17 @@ def assert_not_warns(*expected_warning_types: type[Warning]) -> Iterable[None]:
             raise AssertionError(msg)
         else:
             raise AssertionError(f"Expected no warnings, caught {len(ws)}")
+
+
+@contextlib.contextmanager
+def disable_warnings(*warning_types: type[Warning]) -> Iterable[None]:
+    """Context manager to disable warnings of a given type."""
+    with warnings.catch_warnings():
+        if not warning_types:
+            # Ignore all warnings
+            warnings.simplefilter("ignore")
+        else:
+            # Ignore all warnings of specified types
+            for warning_type in warning_types:
+                warnings.simplefilter("ignore", warning_type)
+        yield

--- a/tests/units/meta/test_test_extras.py
+++ b/tests/units/meta/test_test_extras.py
@@ -18,7 +18,7 @@ import warnings
 
 import pytest
 
-from tests.cases import assert_not_warns
+from tests.cases import assert_not_warns, disable_warnings
 
 
 class OtherWarningSubclass(Warning):
@@ -80,4 +80,38 @@ class TestNotWarns:
         """Test that nesting multiple copies of assert_not_warns works."""
         with pytest.raises(AssertionError):
             with assert_not_warns(OtherWarningSubclass), assert_not_warns(UserWarning):
+                warnings.warn("A warning!", OtherWarningSubclass)
+
+
+class TestDisableWarnings:
+    def test_specific_class(self):
+        """Test the disable_warnings context manager with a specific class."""
+        with assert_not_warns():
+            with disable_warnings(SubclassOfUserWarning):
+                warnings.warn("A warning!", SubclassOfUserWarning)
+
+    def test_specific_classes(self):
+        """Test the disable_warnings context manager with multiple specific classes."""
+        with assert_not_warns():
+            with disable_warnings(SubclassOfUserWarning, SecondSubclassOfUserWarning):
+                warnings.warn("A warning!", SubclassOfUserWarning)
+                warnings.warn("A warning!", SecondSubclassOfUserWarning)
+
+    def test_disable_all(self):
+        """Test the disable_warnings context manager in the default case."""
+        with assert_not_warns():
+            with disable_warnings():
+                warnings.warn("A warning!", SubclassOfUserWarning)
+                warnings.warn("A warning!", SecondSubclassOfUserWarning)
+
+    def test_allows_other_warnings_single(self):
+        """Test the disable_warnings context manager with a specific class and a different warning."""
+        with pytest.warns(OtherWarningSubclass):
+            with disable_warnings(UserWarning):
+                warnings.warn("A warning!", OtherWarningSubclass)
+
+    def test_allows_other_warnings_multiple(self):
+        """Test the disable_warnings context manager with multiple classes and a different warning."""
+        with pytest.warns(OtherWarningSubclass):
+            with disable_warnings(SubclassOfUserWarning, SecondSubclassOfUserWarning):
                 warnings.warn("A warning!", OtherWarningSubclass)

--- a/tests/units/test_decorator_combinations.py
+++ b/tests/units/test_decorator_combinations.py
@@ -17,7 +17,6 @@ Tests for the pairwise combinations of decorators.
 """
 
 import itertools
-from contextlib import nullcontext
 from typing import Any, Optional, TypeVar
 from unittest.mock import patch
 
@@ -31,7 +30,7 @@ from gpytorch.means import ZeroMean
 from gpytorch.mlls import VariationalELBO
 from typing_extensions import TypedDict
 
-from tests.cases import assert_not_warns, get_default_rng, maybe_throws, maybe_warns
+from tests.cases import assert_not_warns, disable_warnings, get_default_rng, maybe_throws, maybe_warns
 
 # not super happy about importing HigherRankKernel/HigherRankMean from another test file - these should probably be
 # moved to some more central location
@@ -628,7 +627,7 @@ def test_combinations(
     expected_error_class, expected_error_message = EXPECTED_COMBINATION_APPLY_ERRORS.get(combination, (None, None))
     if expected_error_class is not None or expected_warning_class is not None:
         # If we expect some other error or warning, we might also get these warnings too, so ignore them.
-        warnings_context = nullcontext()
+        warnings_context = disable_warnings(OverwrittenMethodWarning, UnexpectedMethodWarning)
     else:
         # Otherwise, we shouldn't get any of these spurious warnings.
         warnings_context = assert_not_warns(OverwrittenMethodWarning, UnexpectedMethodWarning)

--- a/tests/units/test_decorator_combinations.py
+++ b/tests/units/test_decorator_combinations.py
@@ -615,7 +615,6 @@ def test_combinations(
         dataset,
     ) = _initialise_decorator_pair(upper_details, lower_details, batch_mode=batch_size is not None)
     all_decorators = [upper_decorator, *upper_requirements, lower_decorator, *lower_requirements, *batch_requirements]
-    print([type(d).__name__ for d in all_decorators])
 
     if batch_size is not None and any(isinstance(d, DirichletKernelMulticlassClassification) for d in all_decorators):
         pytest.skip("DirichletKernelMulticlassClassification is not compatible with VariationalInference")

--- a/vanguard/classification/binary.py
+++ b/vanguard/classification/binary.py
@@ -95,9 +95,25 @@ class BinaryClassification(Decorator):
     @property
     @override
     def safe_updates(self) -> dict[type, set[str]]:
+        # pylint: disable=import-outside-toplevel
+        from vanguard.features import HigherRankFeatures
+        from vanguard.learning import LearnYNoise
+        from vanguard.normalise import NormaliseY
+        from vanguard.standardise import DisableStandardScaling
+        from vanguard.warps import SetInputWarp, SetWarp
+        # pylint: enable=import-outside-toplevel
+
         return self._add_to_safe_updates(
             super().safe_updates,
-            {VariationalInference: {"__init__", "_predictive_likelihood", "_fuzzy_predictive_likelihood"}},
+            {
+                VariationalInference: {"__init__", "_predictive_likelihood", "_fuzzy_predictive_likelihood"},
+                DisableStandardScaling: {"_input_standardise_modules"},
+                HigherRankFeatures: {"__init__"},
+                LearnYNoise: {"__init__"},
+                NormaliseY: {"__init__", "warn_normalise_y"},
+                SetInputWarp: {"__init__"},
+                SetWarp: {"__init__", "_loss", "_sgd_round", "warn_normalise_y", "_unwarp_values"},
+            },
         )
 
     def _decorate_class(self, cls: type[ControllerT]) -> type[ControllerT]:

--- a/vanguard/classification/categorical.py
+++ b/vanguard/classification/categorical.py
@@ -88,11 +88,23 @@ class CategoricalClassification(Decorator):
     @property
     @override
     def safe_updates(self) -> dict[type, set[str]]:
+        # pylint: disable=import-outside-toplevel
+        from vanguard.learning import LearnYNoise
+        from vanguard.normalise import NormaliseY
+        from vanguard.standardise import DisableStandardScaling
+        from vanguard.warps import SetInputWarp, SetWarp
+        # pylint: enable=import-outside-toplevel
+
         return self._add_to_safe_updates(
             super().safe_updates,
             {
                 VariationalInference: {"__init__", "_predictive_likelihood", "_fuzzy_predictive_likelihood"},
                 Multitask: {"__init__", "_match_mean_shape_to_kernel"},
+                DisableStandardScaling: {"_input_standardise_modules"},
+                LearnYNoise: {"__init__"},
+                NormaliseY: {"__init__", "warn_normalise_y"},
+                SetInputWarp: {"__init__"},
+                SetWarp: {"__init__", "_loss", "_sgd_round", "warn_normalise_y", "_unwarp_values"},
             },
         )
 
@@ -100,7 +112,7 @@ class CategoricalClassification(Decorator):
         decorator = self
 
         @Classification(ignore_all=True)
-        @wraps_class(cls)
+        @wraps_class(cls, decorator_source=self)
         class InnerClass(cls, ClassificationMixin):
             """
             A wrapper for implementing categorical classification.

--- a/vanguard/classification/dirichlet.py
+++ b/vanguard/classification/dirichlet.py
@@ -87,9 +87,23 @@ class DirichletMulticlassClassification(Decorator):
     @property
     @override
     def safe_updates(self) -> dict[type, set[str]]:
+        # pylint: disable=import-outside-toplevel
+        from vanguard.learning import LearnYNoise
+        from vanguard.normalise import NormaliseY
+        from vanguard.standardise import DisableStandardScaling
+        from vanguard.warps import SetInputWarp, SetWarp
+        # pylint: enable=import-outside-toplevel
+
         return self._add_to_safe_updates(
             super().safe_updates,
-            {VariationalInference: {"__init__", "_predictive_likelihood", "_fuzzy_predictive_likelihood"}},
+            {
+                VariationalInference: {"__init__", "_predictive_likelihood", "_fuzzy_predictive_likelihood"},
+                DisableStandardScaling: {"_input_standardise_modules"},
+                LearnYNoise: {"__init__"},
+                NormaliseY: {"__init__", "warn_normalise_y"},
+                SetInputWarp: {"__init__"},
+                SetWarp: {"__init__", "_loss", "_sgd_round", "warn_normalise_y", "_unwarp_values"},
+            },
         )
 
     def _decorate_class(self, cls: type[ControllerT]) -> type[ControllerT]:

--- a/vanguard/hierarchical/base.py
+++ b/vanguard/hierarchical/base.py
@@ -73,7 +73,7 @@ class BaseHierarchicalHyperparameters(Decorator):
     def _decorate_class(self, cls: type[ControllerT]) -> type[ControllerT]:
         decorator = self
 
-        @wraps_class(cls)
+        @wraps_class(cls, decorator_source=self)
         class InnerClass(cls):
             @classmethod
             def new(cls, instance: Self, **kwargs: Any) -> Self:

--- a/vanguard/hierarchical/laplace.py
+++ b/vanguard/hierarchical/laplace.py
@@ -109,9 +109,25 @@ class LaplaceHierarchicalHyperparameters(BaseHierarchicalHyperparameters):
     @property
     @override
     def safe_updates(self) -> dict[type, set[str]]:
+        # pylint: disable=import-outside-toplevel
+        from vanguard.learning import LearnYNoise
+        from vanguard.multitask import Multitask
+        from vanguard.normalise import NormaliseY
+        from vanguard.standardise import DisableStandardScaling
+        from vanguard.warps import SetInputWarp, SetWarp
+        # pylint: enable=import-outside-toplevel
+
         return self._add_to_safe_updates(
             super().safe_updates,
-            {VariationalInference: {"__init__", "_predictive_likelihood", "_fuzzy_predictive_likelihood"}},
+            {
+                VariationalInference: {"__init__", "_predictive_likelihood", "_fuzzy_predictive_likelihood"},
+                DisableStandardScaling: {"_input_standardise_modules"},
+                LearnYNoise: {"__init__"},
+                Multitask: {"__init__", "_match_mean_shape_to_kernel"},
+                NormaliseY: {"__init__", "warn_normalise_y"},
+                SetInputWarp: {"__init__"},
+                SetWarp: {"__init__", "_loss", "_sgd_round", "warn_normalise_y", "_unwarp_values"},
+            },
         )
 
     def _decorate_class(self, cls: type[ControllerT]) -> type[ControllerT]:

--- a/vanguard/hierarchical/variational.py
+++ b/vanguard/hierarchical/variational.py
@@ -106,9 +106,23 @@ class VariationalHierarchicalHyperparameters(BaseHierarchicalHyperparameters):
     @property
     @override
     def safe_updates(self) -> dict[type, set[str]]:
+        # pylint: disable=import-outside-toplevel
+        from vanguard.learning import LearnYNoise
+        from vanguard.multitask import Multitask
+        from vanguard.normalise import NormaliseY
+        from vanguard.standardise import DisableStandardScaling
+        from vanguard.warps import SetInputWarp, SetWarp
+        # pylint: enable=import-outside-toplevel
+
         return self._add_to_safe_updates(
             super().safe_updates,
             {
+                DisableStandardScaling: {"_input_standardise_modules"},
+                LearnYNoise: {"__init__"},
+                Multitask: {"__init__", "_match_mean_shape_to_kernel"},
+                NormaliseY: {"__init__", "warn_normalise_y"},
+                SetInputWarp: {"__init__"},
+                SetWarp: {"__init__", "_loss", "_sgd_round", "warn_normalise_y", "_unwarp_values"},
                 VariationalInference: {"__init__", "_predictive_likelihood", "_fuzzy_predictive_likelihood"},
             },
         )

--- a/vanguard/learning.py
+++ b/vanguard/learning.py
@@ -61,15 +61,89 @@ class LearnYNoise(Decorator):
     @property
     @override
     def safe_updates(self) -> dict[type, set[str]]:
+        # pylint: disable=import-outside-toplevel
+        from vanguard.classification import (
+            BinaryClassification,
+            CategoricalClassification,
+            DirichletMulticlassClassification,
+        )
+        from vanguard.classification.kernel import DirichletKernelMulticlassClassification
+        from vanguard.features import HigherRankFeatures
+        from vanguard.hierarchical import LaplaceHierarchicalHyperparameters, VariationalHierarchicalHyperparameters
+        from vanguard.multitask import Multitask
+        from vanguard.normalise import NormaliseY
+        from vanguard.standardise import DisableStandardScaling
+        from vanguard.warps import SetInputWarp, SetWarp
+        # pylint: enable=import-outside-toplevel
+
         return self._add_to_safe_updates(
             super().safe_updates,
             {
+                BinaryClassification: {
+                    "__init__",
+                    "classify_points",
+                    "classify_fuzzy_points",
+                    "_get_predictions_from_prediction_means",
+                    "warn_normalise_y",
+                },
+                CategoricalClassification: {
+                    "__init__",
+                    "classify_points",
+                    "classify_fuzzy_points",
+                    "_get_predictions_from_posterior",
+                    "warn_normalise_y",
+                },
                 ClassificationMixin: {"classify_points", "classify_fuzzy_points"},
                 Classification: {
                     "posterior_over_point",
                     "posterior_over_fuzzy_point",
                     "fuzzy_predictive_likelihood",
                     "predictive_likelihood",
+                },
+                DirichletKernelMulticlassClassification: {
+                    "__init__",
+                    "classify_points",
+                    "classify_fuzzy_points",
+                    "_get_predictions_from_prediction_means",
+                },
+                DirichletMulticlassClassification: {
+                    "__init__",
+                    "_loss",
+                    "_noise_transform",
+                    "classify_points",
+                    "classify_fuzzy_points",
+                    "_get_predictions_from_prediction_means",
+                    "warn_normalise_y",
+                },
+                DisableStandardScaling: {"_input_standardise_modules"},
+                HigherRankFeatures: {"__init__"},
+                LaplaceHierarchicalHyperparameters: {
+                    "__init__",
+                    "_compute_hyperparameter_laplace_approximation",
+                    "_compute_loss_hessian",
+                    "_fuzzy_predictive_likelihood",
+                    "_get_posterior_over_fuzzy_point_in_eval_mode",
+                    "_get_posterior_over_point",
+                    "_gp_forward",
+                    "_predictive_likelihood",
+                    "_sample_and_set_hyperparameters",
+                    "_sgd_round",
+                    "_update_hyperparameter_posterior",
+                    "auto_temperature",
+                },
+                LearnYNoise: {"__init__"},
+                Multitask: {"__init__", "_match_mean_shape_to_kernel"},
+                NormaliseY: {"__init__", "warn_normalise_y"},
+                SetInputWarp: {"__init__"},
+                SetWarp: {"__init__", "_loss", "_sgd_round", "warn_normalise_y", "_unwarp_values"},
+                VariationalHierarchicalHyperparameters: {
+                    "__init__",
+                    "_fuzzy_predictive_likelihood",
+                    "_get_posterior_over_fuzzy_point_in_eval_mode",
+                    "_get_posterior_over_point",
+                    "_gp_forward",
+                    "_loss",
+                    "_predictive_likelihood",
                 },
                 VariationalInference: {"__init__", "_predictive_likelihood", "_fuzzy_predictive_likelihood"},
             },

--- a/vanguard/normalise.py
+++ b/vanguard/normalise.py
@@ -87,17 +87,78 @@ class NormaliseY(Decorator):
     @property
     @override
     def safe_updates(self) -> dict[type, set[str]]:
+        # pylint: disable=import-outside-toplevel
+        from vanguard.classification import BinaryClassification, CategoricalClassification
+        from vanguard.classification.kernel import DirichletKernelMulticlassClassification
+        from vanguard.features import HigherRankFeatures
+        from vanguard.hierarchical import LaplaceHierarchicalHyperparameters, VariationalHierarchicalHyperparameters
+        from vanguard.learning import LearnYNoise
+        from vanguard.multitask import Multitask
+        from vanguard.standardise import DisableStandardScaling
+        from vanguard.warps import SetInputWarp, SetWarp
+        # pylint: enable=import-outside-toplevel
+
         return self._add_to_safe_updates(
             super().safe_updates,
             {
+                BinaryClassification: {
+                    "__init__",
+                    "classify_points",
+                    "classify_fuzzy_points",
+                    "_get_predictions_from_prediction_means",
+                    "warn_normalise_y",
+                },
+                CategoricalClassification: {
+                    "__init__",
+                    "classify_points",
+                    "classify_fuzzy_points",
+                    "_get_predictions_from_posterior",
+                    "warn_normalise_y",
+                },
                 ClassificationMixin: {"classify_points", "classify_fuzzy_points"},
-                VariationalInference: {"__init__", "_predictive_likelihood", "_fuzzy_predictive_likelihood"},
                 Classification: {
                     "posterior_over_point",
                     "posterior_over_fuzzy_point",
                     "fuzzy_predictive_likelihood",
                     "predictive_likelihood",
                 },
+                DirichletKernelMulticlassClassification: {
+                    "__init__",
+                    "classify_points",
+                    "classify_fuzzy_points",
+                    "_get_predictions_from_prediction_means",
+                },
+                DisableStandardScaling: {"_input_standardise_modules"},
+                HigherRankFeatures: {"__init__"},
+                LaplaceHierarchicalHyperparameters: {
+                    "__init__",
+                    "_compute_hyperparameter_laplace_approximation",
+                    "_compute_loss_hessian",
+                    "_fuzzy_predictive_likelihood",
+                    "_get_posterior_over_fuzzy_point_in_eval_mode",
+                    "_get_posterior_over_point",
+                    "_gp_forward",
+                    "_predictive_likelihood",
+                    "_sample_and_set_hyperparameters",
+                    "_sgd_round",
+                    "_update_hyperparameter_posterior",
+                    "auto_temperature",
+                },
+                LearnYNoise: {"__init__"},
+                Multitask: {"__init__", "_match_mean_shape_to_kernel"},
+                NormaliseY: {"__init__", "warn_normalise_y"},
+                SetInputWarp: {"__init__"},
+                SetWarp: {"__init__", "_loss", "_sgd_round", "warn_normalise_y", "_unwarp_values"},
+                VariationalHierarchicalHyperparameters: {
+                    "__init__",
+                    "_fuzzy_predictive_likelihood",
+                    "_get_posterior_over_fuzzy_point_in_eval_mode",
+                    "_get_posterior_over_point",
+                    "_gp_forward",
+                    "_loss",
+                    "_predictive_likelihood",
+                },
+                VariationalInference: {"__init__", "_predictive_likelihood", "_fuzzy_predictive_likelihood"},
             },
         )
 

--- a/vanguard/standardise.py
+++ b/vanguard/standardise.py
@@ -21,9 +21,7 @@ from typing import Any, TypeVar
 from typing_extensions import override
 
 from vanguard.base import GPController
-from vanguard.classification.mixin import Classification, ClassificationMixin
 from vanguard.decoratorutils import Decorator, wraps_class
-from vanguard.variational import VariationalInference
 
 ControllerT = TypeVar("ControllerT", bound=GPController)
 
@@ -62,15 +60,91 @@ class DisableStandardScaling(Decorator):
     @property
     @override
     def safe_updates(self) -> dict[type, set[str]]:
+        # pylint: disable=import-outside-toplevel
+        from vanguard.classification import (
+            BinaryClassification,
+            CategoricalClassification,
+            DirichletMulticlassClassification,
+        )
+        from vanguard.classification.kernel import DirichletKernelMulticlassClassification
+        from vanguard.classification.mixin import Classification, ClassificationMixin
+        from vanguard.features import HigherRankFeatures
+        from vanguard.hierarchical import LaplaceHierarchicalHyperparameters, VariationalHierarchicalHyperparameters
+        from vanguard.learning import LearnYNoise
+        from vanguard.multitask import Multitask
+        from vanguard.normalise import NormaliseY
+        from vanguard.variational import VariationalInference
+        from vanguard.warps import SetInputWarp, SetWarp
+        # pylint: enable=import-outside-toplevel
+
         return self._add_to_safe_updates(
             super().safe_updates,
             {
+                BinaryClassification: {
+                    "__init__",
+                    "classify_points",
+                    "classify_fuzzy_points",
+                    "_get_predictions_from_prediction_means",
+                    "warn_normalise_y",
+                },
+                CategoricalClassification: {
+                    "__init__",
+                    "classify_points",
+                    "classify_fuzzy_points",
+                    "_get_predictions_from_posterior",
+                    "warn_normalise_y",
+                },
                 ClassificationMixin: {"classify_points", "classify_fuzzy_points"},
                 Classification: {
                     "posterior_over_point",
                     "posterior_over_fuzzy_point",
                     "fuzzy_predictive_likelihood",
                     "predictive_likelihood",
+                },
+                DirichletMulticlassClassification: {
+                    "__init__",
+                    "_loss",
+                    "_noise_transform",
+                    "classify_points",
+                    "classify_fuzzy_points",
+                    "_get_predictions_from_prediction_means",
+                    "warn_normalise_y",
+                },
+                DirichletKernelMulticlassClassification: {
+                    "__init__",
+                    "classify_points",
+                    "classify_fuzzy_points",
+                    "_get_predictions_from_prediction_means",
+                },
+                DisableStandardScaling: {"_input_standardise_modules"},
+                HigherRankFeatures: {"__init__"},
+                LaplaceHierarchicalHyperparameters: {
+                    "__init__",
+                    "_compute_hyperparameter_laplace_approximation",
+                    "_compute_loss_hessian",
+                    "_fuzzy_predictive_likelihood",
+                    "_get_posterior_over_fuzzy_point_in_eval_mode",
+                    "_get_posterior_over_point",
+                    "_gp_forward",
+                    "_predictive_likelihood",
+                    "_sample_and_set_hyperparameters",
+                    "_sgd_round",
+                    "_update_hyperparameter_posterior",
+                    "auto_temperature",
+                },
+                LearnYNoise: {"__init__"},
+                Multitask: {"__init__", "_match_mean_shape_to_kernel"},
+                NormaliseY: {"__init__", "warn_normalise_y"},
+                SetInputWarp: {"__init__"},
+                SetWarp: {"__init__", "_loss", "_sgd_round", "warn_normalise_y", "_unwarp_values"},
+                VariationalHierarchicalHyperparameters: {
+                    "__init__",
+                    "_fuzzy_predictive_likelihood",
+                    "_get_posterior_over_fuzzy_point_in_eval_mode",
+                    "_get_posterior_over_point",
+                    "_gp_forward",
+                    "_loss",
+                    "_predictive_likelihood",
                 },
                 VariationalInference: {"__init__", "_predictive_likelihood", "_fuzzy_predictive_likelihood"},
             },

--- a/vanguard/warps/decorator.py
+++ b/vanguard/warps/decorator.py
@@ -27,9 +27,7 @@ from typing_extensions import Self, override
 from vanguard import utils
 from vanguard.base import GPController
 from vanguard.base.posteriors import Posterior
-from vanguard.classification.mixin import Classification, ClassificationMixin
 from vanguard.decoratorutils import Decorator, process_args, wraps_class
-from vanguard.variational import VariationalInference
 from vanguard.warps.basefunction import WarpFunction
 from vanguard.warps.intermediate import is_intermediate_warp_function
 
@@ -62,17 +60,87 @@ class SetWarp(Decorator):
     @property
     @override
     def safe_updates(self) -> dict[type, set[str]]:
+        # pylint: disable=import-outside-toplevel
+        from vanguard.classification import (
+            BinaryClassification,
+            CategoricalClassification,
+            DirichletMulticlassClassification,
+        )
+        from vanguard.classification.mixin import Classification, ClassificationMixin
+        from vanguard.features import HigherRankFeatures
+        from vanguard.hierarchical import LaplaceHierarchicalHyperparameters, VariationalHierarchicalHyperparameters
+        from vanguard.learning import LearnYNoise
+        from vanguard.multitask import Multitask
+        from vanguard.normalise import NormaliseY
+        from vanguard.standardise import DisableStandardScaling
+        from vanguard.variational import VariationalInference
+        from vanguard.warps import SetInputWarp
+        # pylint: enable=import-outside-toplevel
+
         return self._add_to_safe_updates(
             super().safe_updates,
             {
-                ClassificationMixin: {"classify_points", "classify_fuzzy_points"},
-                VariationalInference: {"__init__", "_fuzzy_predictive_likelihood", "_predictive_likelihood"},
-                Classification: {
-                    "predictive_likelihood",
-                    "posterior_over_point",
-                    "fuzzy_predictive_likelihood",
-                    "posterior_over_fuzzy_point",
+                BinaryClassification: {
+                    "__init__",
+                    "classify_points",
+                    "classify_fuzzy_points",
+                    "_get_predictions_from_prediction_means",
+                    "warn_normalise_y",
                 },
+                CategoricalClassification: {
+                    "__init__",
+                    "classify_points",
+                    "classify_fuzzy_points",
+                    "_get_predictions_from_posterior",
+                    "warn_normalise_y",
+                },
+                ClassificationMixin: {"classify_points", "classify_fuzzy_points"},
+                Classification: {
+                    "posterior_over_point",
+                    "posterior_over_fuzzy_point",
+                    "fuzzy_predictive_likelihood",
+                    "predictive_likelihood",
+                },
+                DisableStandardScaling: {"_input_standardise_modules"},
+                DirichletMulticlassClassification: {
+                    "__init__",
+                    "_loss",
+                    "_noise_transform",
+                    "classify_points",
+                    "classify_fuzzy_points",
+                    "_get_predictions_from_prediction_means",
+                    "warn_normalise_y",
+                },
+                HigherRankFeatures: {"__init__"},
+                LaplaceHierarchicalHyperparameters: {
+                    "__init__",
+                    "_compute_hyperparameter_laplace_approximation",
+                    "_compute_loss_hessian",
+                    "_fuzzy_predictive_likelihood",
+                    "_get_posterior_over_fuzzy_point_in_eval_mode",
+                    "_get_posterior_over_point",
+                    "_gp_forward",
+                    "_predictive_likelihood",
+                    "_sample_and_set_hyperparameters",
+                    "_sgd_round",
+                    "_update_hyperparameter_posterior",
+                    "auto_temperature",
+                },
+                LearnYNoise: {"__init__"},
+                Multitask: {"__init__", "_match_mean_shape_to_kernel"},
+                NormaliseY: {"__init__", "warn_normalise_y"},
+                SetInputWarp: {"__init__"},
+                SetWarp: {"__init__", "_loss", "_sgd_round", "warn_normalise_y", "_unwarp_values"},
+                VariationalHierarchicalHyperparameters: {
+                    "__init__",
+                    "_fuzzy_predictive_likelihood",
+                    "_get_posterior_over_fuzzy_point_in_eval_mode",
+                    "_get_posterior_over_point",
+                    "_gp_forward",
+                    "_loss",
+                    "_predictive_likelihood",
+                },
+                VariationalInference: {"__init__", "_predictive_likelihood", "_fuzzy_predictive_likelihood"},
             },
         )
 

--- a/vanguard/warps/input.py
+++ b/vanguard/warps/input.py
@@ -88,17 +88,92 @@ class SetInputWarp(Decorator):
     @property
     @override
     def safe_updates(self) -> dict[type, set[str]]:
+        # pylint: disable=import-outside-toplevel
+        from vanguard.classification import (
+            BinaryClassification,
+            CategoricalClassification,
+            DirichletMulticlassClassification,
+        )
+        from vanguard.classification.kernel import DirichletKernelMulticlassClassification
+        from vanguard.features import HigherRankFeatures
+        from vanguard.hierarchical import LaplaceHierarchicalHyperparameters, VariationalHierarchicalHyperparameters
+        from vanguard.learning import LearnYNoise
+        from vanguard.multitask import Multitask
+        from vanguard.normalise import NormaliseY
+        from vanguard.standardise import DisableStandardScaling
+        from vanguard.warps import SetWarp
+        # pylint: enable=import-outside-toplevel
+
         return self._add_to_safe_updates(
             super().safe_updates,
             {
-                ClassificationMixin: {"classify_points", "classify_fuzzy_points"},
-                VariationalInference: {"__init__", "_fuzzy_predictive_likelihood", "_predictive_likelihood"},
-                Classification: {
-                    "predictive_likelihood",
-                    "posterior_over_point",
-                    "fuzzy_predictive_likelihood",
-                    "posterior_over_fuzzy_point",
+                BinaryClassification: {
+                    "__init__",
+                    "classify_points",
+                    "classify_fuzzy_points",
+                    "_get_predictions_from_prediction_means",
+                    "warn_normalise_y",
                 },
+                CategoricalClassification: {
+                    "__init__",
+                    "classify_points",
+                    "classify_fuzzy_points",
+                    "_get_predictions_from_posterior",
+                    "warn_normalise_y",
+                },
+                ClassificationMixin: {"classify_points", "classify_fuzzy_points"},
+                Classification: {
+                    "posterior_over_point",
+                    "posterior_over_fuzzy_point",
+                    "fuzzy_predictive_likelihood",
+                    "predictive_likelihood",
+                },
+                DirichletKernelMulticlassClassification: {
+                    "__init__",
+                    "classify_points",
+                    "classify_fuzzy_points",
+                    "_get_predictions_from_prediction_means",
+                },
+                DirichletMulticlassClassification: {
+                    "__init__",
+                    "_loss",
+                    "_noise_transform",
+                    "classify_points",
+                    "classify_fuzzy_points",
+                    "_get_predictions_from_prediction_means",
+                    "warn_normalise_y",
+                },
+                DisableStandardScaling: {"_input_standardise_modules"},
+                HigherRankFeatures: {"__init__"},
+                LaplaceHierarchicalHyperparameters: {
+                    "__init__",
+                    "_compute_hyperparameter_laplace_approximation",
+                    "_compute_loss_hessian",
+                    "_fuzzy_predictive_likelihood",
+                    "_get_posterior_over_fuzzy_point_in_eval_mode",
+                    "_get_posterior_over_point",
+                    "_gp_forward",
+                    "_predictive_likelihood",
+                    "_sample_and_set_hyperparameters",
+                    "_sgd_round",
+                    "_update_hyperparameter_posterior",
+                    "auto_temperature",
+                },
+                LearnYNoise: {"__init__"},
+                Multitask: {"__init__", "_match_mean_shape_to_kernel"},
+                NormaliseY: {"__init__", "warn_normalise_y"},
+                SetInputWarp: {"__init__"},
+                SetWarp: {"__init__", "_loss", "_sgd_round", "warn_normalise_y", "_unwarp_values"},
+                VariationalHierarchicalHyperparameters: {
+                    "__init__",
+                    "_fuzzy_predictive_likelihood",
+                    "_get_posterior_over_fuzzy_point_in_eval_mode",
+                    "_get_posterior_over_point",
+                    "_gp_forward",
+                    "_loss",
+                    "_predictive_likelihood",
+                },
+                VariationalInference: {"__init__", "_predictive_likelihood", "_fuzzy_predictive_likelihood"},
             },
         )
 


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Feature
- Tests

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

- Add missing entries to all `safe_updates` (closes #123)
- Remove temporary tests
- Incorporate testing for these warnings into main test_decorator_combinations test
- Rework handling of dependency requirements in test_decorator_combinations to avoid duplicate decorators
- Added warnings to some decorators against doubled-up usage

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

- test_decorator_combinations has been changed to test this

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

No

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
