### PR TITLE
fix: decorator warnings raised by test_basedecorator.py

### DIFF
--- a/tests/units/test_decorator_combinations.py
+++ b/tests/units/test_decorator_combinations.py
@@ -379,10 +379,18 @@ EXPECTED_COMBINATION_APPLY_ERRORS: dict[tuple[type[Decorator], type[Decorator]],
 # (upper, lower) -> (warning type, message regex)
 # Warnings we expect to be raised on decorator application.
 EXPECTED_COMBINATION_APPLY_WARNINGS: dict[tuple[type[Decorator], type[Decorator]], tuple[type[Warning], str]] = {
-    (NormaliseY, DirichletMulticlassClassification): (
-        BadCombinationWarning,
-        "NormaliseY should not be used above classification decorators - this may lead to unexpected behaviour.",
-    ),
+    **{
+        (NormaliseY, lower): (
+            BadCombinationWarning,
+            "NormaliseY should not be used above classification decorators - this may lead to unexpected behaviour.",
+        )
+        for lower in [
+            BinaryClassification,
+            CategoricalClassification,
+            DirichletMulticlassClassification,
+            DirichletKernelMulticlassClassification,
+        ]
+    },
     **{
         (VariationalInference, lower): (
             BadCombinationWarning,

--- a/vanguard/base/gpcontroller.py
+++ b/vanguard/base/gpcontroller.py
@@ -141,7 +141,8 @@ class GPController(BaseGPController, metaclass=_StoreInitValues):
                 warnings.warn(
                     f"You are trying to set gradient_every (in this case to {gradient_every}) in batch mode."
                     "This does not make mathematical sense and your value of gradient every will be ignored "
-                    " and replaced by 1."
+                    " and replaced by 1.",
+                    stacklevel=2,
                 )
             gradient_every = 1
 

--- a/vanguard/decoratorutils/basedecorator.py
+++ b/vanguard/decoratorutils/basedecorator.py
@@ -185,6 +185,9 @@ class Decorator:
         cls_methods = {
             key
             for key, value in getmembers(cls, isfunction)
+            # only functions that are actually from this class (as opposed to a superclass)
+            if key in cls.__dict__
+            # ignore functions defined in safe_updates
             if key not in self.safe_updates.get(self._get_method_implementation(cls, key), set())
             # beartype does weird things with __sizeof__; however, it's of no concern to us, and we never make use of
             # this dunder attribute. See https://github.com/beartype/beartype/blob/v0.19.0/beartype/_decor/_decortype.py
@@ -216,7 +219,7 @@ class Decorator:
             else:
                 warnings.warn(message, errors.UnexpectedMethodWarning, stacklevel=4)
 
-        overwritten_methods = {method for method in cls_methods if method in cls.__dict__} - ignore_methods
+        overwritten_methods = cls_methods - ignore_methods - extra_methods
         if overwritten_methods:
             if __debug__:
                 overwritten_method_messages = "\n".join(

--- a/vanguard/distribute/decorator.py
+++ b/vanguard/distribute/decorator.py
@@ -275,7 +275,7 @@ class Distributed(TopMostDecorator, Generic[ControllerT]):
                     **self._expert_init_kwargs,
                 )
 
-            def fit(self, n_sgd_iters: int = 10, gradient_every: int = 10) -> torch.Tensor:
+            def fit(self, n_sgd_iters: int = 10, gradient_every: Optional[int] = None) -> torch.Tensor:
                 """
                 Create the expert controllers.
 

--- a/vanguard/utils.py
+++ b/vanguard/utils.py
@@ -16,15 +16,17 @@
 Contain some small utilities of use in some cases.
 """
 
+import contextlib
 import functools
 import os
 import warnings
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from typing import Any, Callable, Optional, TypeVar
 
 import numpy as np
 import numpy.typing
 import torch
+from typing_extensions import ContextManager
 
 from vanguard.warnings import _RE_INCORRECT_LIKELIHOOD_PARAMETER
 
@@ -253,3 +255,12 @@ def compose(functions: list[Callable[[T], T]]) -> Callable[[T], T]:
     :return: A single function of type (T -> T) that applies each of the passed functions in series.
     """
     return lambda x: functools.reduce(lambda acc, f: f(acc), reversed(functions), x)
+
+
+@contextlib.contextmanager
+def multi_context(contexts: Iterable[ContextManager]):
+    """Combine multiple context managers into one."""
+    with contextlib.ExitStack() as stack:
+        for context in contexts:
+            stack.enter_context(context)
+        yield


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- Bugfix
- Tests

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

test_basedecorator.py now raises no Unexpected/OverwrittenMethodWarnings - that is, none escape from the tests. The check that raises the warnings has been modified slightly to avoid duplicate warnings. Closes #283.

### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

Running pytest and checking for warnings.

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

No.

### Checklist before requesting a review
- [ ] I have made sure that my PR is not a duplicate.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
