### PR TITLE
ci(docs): exclude dl.acm.org from link check

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -100,6 +100,7 @@ bibtex_bibfiles = [os.path.join(VANGUARD_FOLDER_FILE_PATH, "references.bib")]
 linkcheck_ignore = [
     "https://doi.org",
     "https://artowen.su.domains/mc/",
+    "https://dl.acm.org/doi",
 ]
 linkcheck_timeout = 5
 linkcheck_report_timeouts_as_broken = True


### PR DESCRIPTION
### PR Type
<!--
    What kind of change does this PR introduce? Remove any that do not apply.
-->

- CI related changes

### Description
<!--
    Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
-->

https://dl.acm.org/doi/10.5555/3327345.3327500 and https://dl.acm.org/doi/10.5555/1046920.1194901 have consistently been raising link checker errors for the past week or so. This PR excludes the entire https://dl.acm.org/doi domain from link checking.


### How Has This Been Tested?
<!--
    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

Link checker now passes.

### Does this PR introduce a breaking change?
<!--
    What changes might users need to make in their application due to this PR?.
-->

No.

### Checklist before requesting a review
- [x] I have made sure that my PR is not a duplicate.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
