### PR TITLE
Release 3.1.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -53,7 +53,7 @@ body:
     attributes:
       label: Package version
       description: What version of Vanguard are you using?
-      placeholder: 3.0.1
+      placeholder: 3.1.0
     validations:
       required: true
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,25 @@ Version 4 will be the first stable version.
 ## [Unreleased]
 
 ### Added
+
+-
+
 ### Fixed
+
+-
+
 ### Changed
+
+-
+
 ### Removed
+
+-
+
+### Deprecated
+
+-
+
 
 ## [3.1.0]
 
@@ -33,9 +49,6 @@ Version 4 will be the first stable version.
 - [BREAKING CHANGE] Removed support for old versions of some dependencies; most importantly, we no longer support
   NumPy 1.x. (https://github.com/gchq/Vanguard/pull/511)
 
-### Deprecated
-
--
 
 
 ## [3.0.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Version 4 will be the first stable version.
 ## [Unreleased]
 
 ### Added
+### Fixed
+### Changed
+### Removed
+
+## [3.1.0]
+
+### Added
 
 - Support for Python 3.13. (https://github.com/gchq/Vanguard/pull/511)
 
@@ -93,6 +100,7 @@ Yanked due to build failure.
 [beartype]: https://pypi.org/project/beartype/
 [pre-commit]: https://pre-commit.com/
 
-[Unreleased]: https://github.com/gchq/Vanguard/compare/v3.0.1...HEAD
+[Unreleased]: https://github.com/gchq/Vanguard/compare/v3.1.0...HEAD
+[3.1.0]: https://github.com/gchq/Vanguard/compare/v3.0.1...v3.1.0
 [3.0.1]: https://github.com/gchq/Vanguard/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/gchq/Vanguard/releases/tag/v3.0.0

--- a/vanguard/__init__.py
+++ b/vanguard/__init__.py
@@ -29,5 +29,5 @@ torch.set_default_device(vanguard.utils.DEFAULT_DEVICE)
 
 
 __author__ = "GCHQ"
-__version__ = "3.0.1"
+__version__ = "3.1.0"
 __bibliography__ = _bibliography.find_bibliography()


### PR DESCRIPTION
 - [Release action run](https://github.com/gchq/Vanguard/actions/runs/14103069230)
 - Tests all pass on GPU (unit, integration, doctests, example tests)
 - Version numbers updated